### PR TITLE
Remove buster

### DIFF
--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -8,14 +8,6 @@ SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
 Update: tor
 
 Origin: SecureDrop
-Codename: buster
-Components: main nightlies
-Architectures: amd64
-ValidFor: 6m
-Description: SecureDrop Workstation packages (buster)
-SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
-
-Origin: SecureDrop
 Codename: bullseye
 Components: main nightlies
 Architectures: amd64

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220818-060334+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220818-060334+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a434e0f79c53ced4a5cd8faa2d71609d4b84e432509694480ae03ca6bca82e61
-size 8424560

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220819-060346+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220819-060346+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2321fbe9b57b5b6f8e9d1483d0114f80202903f5c0df026a8cf53e1056e1d1e2
-size 8423048

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220820-060344+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220820-060344+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4eac4bd010ce86e9e3030fa4a0a8d45645d2ca3cf4c40638497c1b1a0c59d597
-size 8424024

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220821-060337+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220821-060337+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b21e05fd25df4d9e740ba5e204785f24439459a392eef415eba32d2ad8a5c137
-size 8423668

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220822-060340+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220822-060340+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b48a42ec7bc4af72acc9804a0cbb56f9dd55d23890b09d64007b3ac2848dc0b
-size 8423088

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220823-060337+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220823-060337+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcd3169c1cace8c7c85cdbe48aa3306b756c408dc69c60eb4ffb588ba25c111c
-size 8423368

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220823-154402+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220823-154402+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cdd419c7416b7aa694c9987c829221de1333560abf2cb547f8c7ef99c9224e9
-size 8423872

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220824-060340+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220824-060340+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39115be8fa04b968d58d074f42e6c071e3ebe43c457e76286b957085adfe45e1
-size 8423144

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220825-060352+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220825-060352+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f59e1d36585e5a03cb5ed99004e3b38bcf5878e613226f00b214c4e6116ebb27
-size 8423092

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220827-060340+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220827-060340+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8cce1312896aac31a2c8bb895178597010d8df9f4562483e8b57a9853706121b
-size 8423336

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220828-060347+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220828-060347+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0c27ab79cb39a1b2800e5079f1b4b35ded6f41cbf60d17751acd0cc334e9ae8
-size 8423764

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220829-060339+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220829-060339+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26418a97e30079b25c77d5dbca158eaecd367e9da26334b724034a957d3c25c5
-size 8423420

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220830-060336+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220830-060336+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bef550f5529e7fff9d1f3540dcb44748668b06a74fa390a7239abb44e984d8ab
-size 8422928

--- a/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220901-060402+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-client_0.8.0-dev-20220901-060402+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fcec05608ec9c9aa68a10f14b08d170af85a00325478241e6d03a5cdf5e69eea
-size 8423568

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220818-060357+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220818-060357+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e6e07a9180b03a3f129a4ab920a4195a82fd0a400bb5b11c9f40598c1ea43ae
-size 4927312

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220819-060353+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220819-060353+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7400072e4f5319466ef5036da8a37f3f198e294347cb8d3f8761b268c6064497
-size 4927336

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220820-060332+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220820-060332+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37cbe2c59848722ff862a4db3ab23b97f1c30e312cf605df0d90d7fb65715df8
-size 4926836

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220821-060345+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220821-060345+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea89b588c2a50da501ca60673bd862194fb1a042ff7469b25aa5d1e2c4e1e274
-size 4926768

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220822-060345+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220822-060345+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2eed8bd4e6066d9ab5699dcefd58e3141c381e81e6776c439231f61f69152ab2
-size 4927280

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220823-060350+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220823-060350+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77b0426d4f02038f82dffefbceb4f56ca1b313e50c8fa71d3a926c4a8a4877f2
-size 4927536

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220823-154340+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220823-154340+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0adfdc87ada0b9a5a33d2c75e979ddfc8afb3cce44e97599bd81abde5f682566
-size 4926988

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220824-060341+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220824-060341+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d6867632a68851d0fdbe30e8281223fda37f351a821dc4092eb480e4edc9ff8
-size 4926528

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220825-060341+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220825-060341+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87f10b9709e76ac3b6ff9226b83fcf8a37c5aae87e06173852cb71c13d10042e
-size 4927348

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220827-060342+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220827-060342+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21c753db750ea6e47869d4d34a50aeb36c6cc5d3aa9dad42f9dcd79a093e18c4
-size 4927288

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220828-060338+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220828-060338+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce47430c16f276b91c065c7043aa78ab540f01a499d2f4d3d52c9e8ff46b8b2a
-size 4927172

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220829-060350+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220829-060350+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91c14abeb241902bdfc1ad59ef308cea98b8f3880b128f9c504c3ca32d699de0
-size 4926988

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220830-060335+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220830-060335+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12d55c75f5dc419aecd63e7713f4dde40d09a770a6cf952ab0e1a84e2db3b601
-size 4926664

--- a/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220901-060402+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-export_0.3.0-dev-20220901-060402+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:062ec2e027bd775f41098d9003ad817c2488c7b02970416c0f86b8f4b384b0ed
-size 4928016

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220818-060516+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220818-060516+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:049293e6c38d2e2263bb7457110b7027bda0673ab53a43acdb6709b578586511
-size 4904

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220819-060357+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220819-060357+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c9b8ab33fdfdf5355baffebe72e747e67c1368d966e2d4aa5dbca6c92fab980
-size 4908

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220820-060348+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220820-060348+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e3e5de8f8a58e773a89b236260f40c8709ad6f23a1d15ad22bf754b306915e10
-size 4908

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220821-060355+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220821-060355+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:078cfc564f03df5e7ce7dc1c7c0d5e3f4b81a86428c10e98336a307f895cc3e8
-size 4904

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220822-060341+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220822-060341+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e12807957877ba210665bc04edbbaa2cbaaf5c1ac5979e5d3988cd01ab5a1233
-size 4908

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220823-060336+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220823-060336+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd251ecc45016424b7bb155f50e529f4e0e6b1cad70a2a2aa7711c7a8ecff512
-size 4900

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220823-154334+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220823-154334+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:15373ed92e37e845693d95155df71db0ec55a26452b5ae795a76d1e246810c46
-size 4904

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220824-060343+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220824-060343+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fac79732280f9332f0eb41c7ef8e92148dc18e4b5814a386acdee7fc3e823cf0
-size 4908

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220825-060353+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220825-060353+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ddd6139d8600314fb88e9125817806cc4f0c5b9004817773fd15aacdc7775e9
-size 4908

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220827-060351+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220827-060351+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a42c45d170df1a341015960a9d879dfeae7b933e540b61c06ed544e5ce82a140
-size 4904

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220828-060353+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220828-060353+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c48333d85599b20418b81b0560f25ef4e90d36b45ee944ef2fa15cbb55076b73
-size 4904

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220829-060338+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220829-060338+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af943e758cbf55cb3f53d9f57284812a14b2ed7319c623338e81755da1459100
-size 4908

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220830-060335+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220830-060335+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3385068628ada60d982d1233187be177c6a74320378f0551cee752ebe877e05c
-size 4904

--- a/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220901-060409+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-keyring_0.1.6-dev-20220901-060409+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:16dacffb81a1f07b8eaa27c150e6a0f4e963136ebd694ed4f1e87a628722cde0
-size 4912

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220818-060335+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220818-060335+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f97ffd801e92d2ae5fa45da4027a633298f73f5ced009f931f933211b3eb8165
-size 4951340

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220819-060343+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220819-060343+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fbbd290a69ee77299f84f8f4564bbde92366cbdb9f70e232daf156c6074ed78c
-size 4950616

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220820-060400+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220820-060400+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be65d36454c432e580613d68ecd03845f46a4886a3545fb0d5ce6a7ea413f4ad
-size 4951036

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220821-060344+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220821-060344+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c0763980c1fbbfd3aeddd47b6f5faf29e8b405f035bccba867214488cc660278
-size 4951192

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220822-060341+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220822-060341+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3c1eec2e3cd792568a8d63715ea78145653b2e753849c0be61ebab897b8cc71
-size 4951652

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220823-060336+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220823-060336+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ef6e47cd887d28d03d1537a49892b3ba449d5b55a58aa11cbf0c6be1fc7e968
-size 4951520

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220823-154350+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220823-154350+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67c49c35e6d4a7d279bc6d386859cba441428c013cad8f41e244bdc641bfb736
-size 4950816

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220824-060402+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220824-060402+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9347a63a9fe48bccb6a45af92a5f724058ca74850b1485469f9b656168a6151
-size 4951184

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220825-060337+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220825-060337+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab39e97ca2a3f7480c472f069dbbc465a13106d6c8006178e85fb4de67e78e16
-size 4951524

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220827-060338+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220827-060338+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46ef8e4e4e703ffa9f821d0d37613b764f9a4cf124b079eff48f6719f5866ea5
-size 4950936

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220828-060338+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220828-060338+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bc1661b08666f373f86c74138d827eaaf569bc4f9728fa34e5df671329dfa6c8
-size 4951368

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220829-060338+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220829-060338+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc06f718f5fe48c2663a13232f14afe9b7a969c5033b1c950ba6f5a7d1fd8771
-size 4951104

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220830-060342+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220830-060342+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a4d8ddf3604aec47329840df9c28ed65fd4c551bd68b5d103f3c31be69b847c
-size 4950764

--- a/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220901-060354+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-log_0.2.0-dev-20220901-060354+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c713fb379d82a397bc70ffebc3b252bb0e69ea99bba7560a2e1416c74090a1e
-size 4951528

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220818-060341+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220818-060341+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f04072ca0ece7702394fb537320ef154378d0125d8c39bf7d07625202f62197a
-size 5543616

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220819-060354+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220819-060354+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df61066500d99dd5777de84143fe39d6cafdc7ba01880e9ee66bb9dac277001f
-size 5544072

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220820-060338+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220820-060338+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e5af53c8a718a6d02491dbd33bf01c700af5b281c5663e8f90ca6b924a89a81
-size 5541984

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220821-060334+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220821-060334+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f066519b39a04e2411e88bfeaa2df5a710a5404c676df2d11b17b0d27796857
-size 5541712

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220822-060350+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220822-060350+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fbe64a2035c82500a97ee4c6ae0eab7c4f7ba32f15fd76bdade9c197ed469699
-size 5542800

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220823-060352+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220823-060352+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d88e42963a11031b5f29d1a6b711b55d1ee758774187c152c25d45490404b7f1
-size 5543484

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220823-154345+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220823-154345+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d2c843322d24c7a7418b7b8b9deac6664c5a74948aa43c5a3b1a9d260559d5a
-size 5543120

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220824-060345+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220824-060345+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c28d17037dba666358744178284436b3de5710cfe6c08f5b233ace7394489f7
-size 5541968

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220825-060412+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220825-060412+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47eea85a8ce9e4ee2a93d87bc93a12149d44d7ec49fd92d50338c97d8a0e4b4e
-size 5541376

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220827-060344+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220827-060344+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec5414d46de183407dc8de7609818470bdf098f23373b16d9977c33ef1798639
-size 5542332

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220828-060339+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220828-060339+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4cb2ada3bc738bca6a9b3403f6a964ee2b8ac82dcec32ea9f39b490a8a457e2b
-size 5542108

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220829-060340+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220829-060340+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c4faf70282960127508f9c206cf29d873aa31f55213d196573a236145e9c327
-size 5543064

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220830-060346+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220830-060346+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e4e61c0a42be89705cee15a2935964d1f0649e4afe5d5c699a7f970df806574c
-size 5542816

--- a/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220901-060404+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-proxy_0.4.0-dev-20220901-060404+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a33c42539016860ef27851d1aa9d0dc58d69bb63556a97ac5771ab33d26c4745
-size 5543124

--- a/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220823-154354+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220823-154354+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05865d1013ce57480dae76bba7e80432200136f21150c8dde828c0b622cc95a7
-size 5824

--- a/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220824-060344+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220824-060344+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:38a28ac8fd0d52422860aa7d3e5a4f463987fbdb20b06b9e201c522124a07f9c
-size 5824

--- a/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220825-060348+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220825-060348+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d58c65707aa4a730cd89060dd8f0a1fcab351d4e54c2ea2085f9c879235b65d
-size 5828

--- a/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220827-060348+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220827-060348+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca65404310478fcc6977068ebd3d6cfcdb1900c04568ac496bd42f1f5853ed1c
-size 5828

--- a/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220828-060343+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220828-060343+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a299699ead4b49b18e15cec8db0241f90425bbcf04d4473d85c552ef0cfc6f6c
-size 5828

--- a/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220829-060347+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220829-060347+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91031981bed2f98b1f9aecd5ce95e326ccbd6e301d227529c7af816d824c97bf
-size 5828

--- a/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220830-060344+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220830-060344+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d92c9f5b462e9599c79a48398eae6dc1f2390be421446444450ef0e5696719b
-size 5824

--- a/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220901-060356+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-config_0.2.0-dev-20220901-060356+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ff210b4b98b18020eaca5c5e5b1ca5a550d42a857249fefa2111e6cd4a9e7a7
-size 5828

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220818-060352+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220818-060352+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c41040a792db060de74bb70ca970ccf6fb0b9fe6de7560af8908ced4d753698
-size 1776

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220819-060336+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220819-060336+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6f44bd61e1e6b553b009b1bf95282c3b1826e2292590d15eb8f61fc55ae576b
-size 1780

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220820-060338+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220820-060338+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9ec7f7b71a39239535bd0d5e3387108869539a175f6305ba29a90338a8633ec
-size 1776

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220821-060338+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220821-060338+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e6863abc0d1fcc720b73452cfedcc273845da04aafe5ee75f4dc669b3bb39e00
-size 1776

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220822-060341+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220822-060341+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7dd9480daea3eb423c30fd65ffc2e467f02f35ff70595b356696045de6f78177
-size 1772

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220823-060332+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220823-060332+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c03c8e90e6edce9ebfc126bdf3e7b47fb584d5ae9d07a9e6ab692a2a1fc86ae
-size 1776

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220823-154343+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220823-154343+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7275efc1defb315c62d7bd2eae22c1226902185b24a1dca776a9034da62ced0b
-size 1776

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220824-060344+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220824-060344+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:171b4b960de6fe7df34938cd0a84e531a2b1b7bab964788bbd198de1b82b0d63
-size 1776

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220825-060343+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220825-060343+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:75b8691fcc108e3f729001e113e530dc75f2bb701ff66d424c4d31ca09ecd2c7
-size 1776

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220827-060342+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220827-060342+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ef24459eff5b7afb732a7c29543b74e2c2a8711c2f58073fb2ba11510f89575
-size 1780

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220828-060359+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220828-060359+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a019599e1c1807f26ddb8b25b63d46801f80f2c697add28ca313fd287128fb8f
-size 1776

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220829-060336+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220829-060336+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b73f60bed5898ccc68c5805366f889a0d36ed968c734b416cf68c99afc6b63c
-size 1772

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220830-060335+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220830-060335+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b051111f16088579a2d43154841fe72525eb346ca61634f220897581300958d
-size 1776

--- a/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220901-060405+buster_all.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-viewer_0.2.0-dev-20220901-060405+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b1b17ccf9d3e0470976cf5005cef756c13e6f2fb99155518d08a67d6c6e107d
-size 1772

--- a/workstation/buster/linux-headers-4.14.186-grsec-workstation_4.14.186-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-headers-4.14.186-grsec-workstation_4.14.186-grsec-workstation-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7048a575d1797b50cb52d56f066488d152fea05d8899a6199d223e3c8f822552
-size 21582516

--- a/workstation/buster/linux-headers-4.14.240-grsec-workstation_4.14.240-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-headers-4.14.240-grsec-workstation_4.14.240-grsec-workstation-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eade17108246475a8711cec5882e20701878d04bfa76e0de95e61a83cdc29c68
-size 24627992

--- a/workstation/buster/linux-headers-4.14.241-grsec-workstation_4.14.241-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-headers-4.14.241-grsec-workstation_4.14.241-grsec-workstation-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e1f43333e75e8ac46aa319157940ea7982ee4f3d0b9fda711d85d77d5b77b2bf
-size 23468540

--- a/workstation/buster/linux-image-4.14.186-grsec-workstation_4.14.186-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-image-4.14.186-grsec-workstation_4.14.186-grsec-workstation-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f66028e8531c4cb6829712e7ab47a5176bdf330a1b4b508ed2f71409ec2682b
-size 55664500

--- a/workstation/buster/linux-image-4.14.240-grsec-workstation_4.14.240-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-image-4.14.240-grsec-workstation_4.14.240-grsec-workstation-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b299e5716820775f7f3a15bd78ceadf741a5202cfe5851776cf5c175f03b6ba7
-size 35319824

--- a/workstation/buster/linux-image-4.14.241-grsec-workstation_4.14.241-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-image-4.14.241-grsec-workstation_4.14.241-grsec-workstation-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:951348d9e237c1a60fa54c130c23ecfcf2691acd74d30fbbeeecd00c83cf5347
-size 57108864

--- a/workstation/buster/securedrop-client_0.0.10+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:726c3da9221bf06f66b23e22cd2be93472a3de33cfbc701c52b9a99fae2a5899
-size 5723508

--- a/workstation/buster/securedrop-client_0.6.0-rc1+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc1+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:046bf288af4be2e4299610e0ec6cf851adab124228d5f8da4706ef1f7a28797a
-size 8332148

--- a/workstation/buster/securedrop-client_0.6.0-rc2+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc2+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f48a00c3c329c6c9d2ea18b58a41be93d7b146381e7ca9d42db46dd8322af35
-size 8373600

--- a/workstation/buster/securedrop-client_0.6.0-rc3+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc3+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7dbf235a9c9374182c24f0db736eabfae6a20d3934ea94e638d21453df0b71d1
-size 8399280

--- a/workstation/buster/securedrop-client_0.6.0-rc4+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc4+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1efd5f8fe8951d07b2d48537b40b6da804b057f8d0b7ecf7d5628eb764a4f8cf
-size 8410300

--- a/workstation/buster/securedrop-client_0.7.0-rc1+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.7.0-rc1+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f9b5a6bcc45520c566159d3664df503695100a6fb75e269362f4d64efcf2435
-size 8475280

--- a/workstation/buster/securedrop-client_0.7.0-rc2+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.7.0-rc2+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a1108497d371f7511836e4b84f155d93e7440ee24a237fa0968702117f4920c
-size 8476484

--- a/workstation/buster/securedrop-client_0.7.0-rc3+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.7.0-rc3+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b882e25cccd464e7e0dc3e26f0ad34fc19409028a777e38d68f7aae8b2a5c134
-size 8476772

--- a/workstation/buster/securedrop-export_0.1.2+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abbe86783c0d3cb31c8ab68a24c4c2095c08384e513f855bb1e1a1d2ada6d527
-size 2831372

--- a/workstation/buster/securedrop-export_0.2.6+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.2.6+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:275d7d9b0c9fca540a2ad25c22777fbb193d4fee611520f09bac0c524883777e
-size 4597676

--- a/workstation/buster/securedrop-keyring_0.1.4+buster_all.deb
+++ b/workstation/buster/securedrop-keyring_0.1.4+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d09f48501f8607560d4ce0e8002382b067217465d81aa7ca36aad1674403f519
-size 6960

--- a/workstation/buster/securedrop-keyring_0.1.5+buster_all.deb
+++ b/workstation/buster/securedrop-keyring_0.1.5+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccb9a18c2ad8ecf757995ce16973a58a470f1845cc985717de263446a89e98ad
-size 9196

--- a/workstation/buster/securedrop-keyring_0.1.6+buster_all.deb
+++ b/workstation/buster/securedrop-keyring_0.1.6+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f74ba4899a0700c80665de9256baf554cb07f8858c2ec59eefe70af14c7e6c14
-size 4836

--- a/workstation/buster/securedrop-log_0.1.2-dev-20220419-061826+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.1.2-dev-20220419-061826+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ecc4e73009a77ed5dfd4e6b6d41412389776d9da60d602d386559ff5f60c0ea
-size 5025604

--- a/workstation/buster/securedrop-proxy_0.1.5+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:143474c572bba0389c59dae81bfa266b1cb1038bff7375457af12ad18b27e860
-size 3142816

--- a/workstation/buster/securedrop-proxy_0.3.1+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.3.1+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e2314d3d5f1a74d48a19d7673fdb816188cbd6901a3d0ded28da1136243a061
-size 4877348

--- a/workstation/buster/securedrop-workstation-config_0.1.0+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.0+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78b1c575af422930ed4a0d3a232054804586b34ed0d79405ce3b5b1efd59f315
-size 1508

--- a/workstation/buster/securedrop-workstation-config_0.1.1+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.1+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:897a115bbeebc81e2e09a63e784eb6e81ba8fc7a4dd252840f7485f7ffa117bf
-size 1548

--- a/workstation/buster/securedrop-workstation-config_0.1.2+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.2+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5cdccf865d37f107d357ab7669a69b98a32bdb2756fe58b12854258525cb0f11
-size 1572

--- a/workstation/buster/securedrop-workstation-config_0.1.4+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.4+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1fc37d8564fd1605477234ab4ff4ee5826f815cb5d4bdd6191cfce0fdc98e205
-size 5208

--- a/workstation/buster/securedrop-workstation-config_0.1.5+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.5+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a3ca50232c715195a4f4b78f4aee85aa9ff5dbb0ae55da778d29187d3138086a
-size 5300

--- a/workstation/buster/securedrop-workstation-config_0.1.6+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.6+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba4002770ef698ad7aa56ecbd93f6f14eba4333a489180d2c60b01ed8ee2475a
-size 5640

--- a/workstation/buster/securedrop-workstation-config_0.1.7+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.7+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e664c5e1eade57f59f1556aed05c2e59d1fb1c8533388c69aa2d5aefb84bb0f
-size 5684

--- a/workstation/buster/securedrop-workstation-grsec_4.14.151-3+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.151-3+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2583efc62e683447c6bc7b79f0b2f54c97ad08d9fed02209074a01a4224b834
-size 3224

--- a/workstation/buster/securedrop-workstation-grsec_4.14.158-1+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.158-1+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:111d7df1c18b89c8d4253f7b76e7ba533d89e1430728872d4574633abec2c9c4
-size 3020

--- a/workstation/buster/securedrop-workstation-grsec_4.14.169+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.169+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa7a77166e9c74cd7ab3b85d3179bb71a4b2e319686563a6e8dd1fb8a6513909
-size 3028

--- a/workstation/buster/securedrop-workstation-grsec_4.14.186+buster1_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.186+buster1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a5a66fad189ecdc64231e698280cefb3b7ea73858b55f8f421502803e8b2e76
-size 3176

--- a/workstation/buster/securedrop-workstation-grsec_4.14.186+buster2_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.186+buster2_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4791a6a3120d3a85501ff2e4c5532bbab01813d5ef8de62b57f79a1fda944fea
-size 3584

--- a/workstation/buster/securedrop-workstation-grsec_4.14.186+buster3_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.186+buster3_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b9e68128c97ba6633190cb2defc73b4c51c029a50a652a56f9718cc0782366b
-size 3648

--- a/workstation/buster/securedrop-workstation-grsec_4.14.186+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.186+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:caf272bc6d2b4aae0eb83978ff95c6df620eeceefc0843eae880a814306f7e85
-size 3060

--- a/workstation/buster/securedrop-workstation-grsec_4.14.240+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.240+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:277805b62d58be7c42d7f485e2d05e7e3f0291ceafe948570a67c2451e8bdb12
-size 3684

--- a/workstation/buster/securedrop-workstation-grsec_4.14.241+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.241+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52a7a4a0ddd7c3385d03376e7d4876d7e19eede162c131426553e7b19dc8b58c
-size 3688

--- a/workstation/buster/securedrop-workstation-svs-disp_0.1.3+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-svs-disp_0.1.3+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6549b61d53f8fa29e5581484b9e6b8d172260e66e1a45140f8a5bf063e6f2429
-size 3268

--- a/workstation/buster/securedrop-workstation-svs-disp_0.1.5+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-svs-disp_0.1.5+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db6ab2a7f87945541fc0eb012c9bcb589dc1e5866302fd8ecea4b39b77662d57
-size 3432

--- a/workstation/buster/securedrop-workstation-svs-disp_0.2.2+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-svs-disp_0.2.2+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1ba8ed23f94ad742ccdc1b9e56c9050f5667b84a8cfcf74d98ace2c9f2d22df
-size 3576

--- a/workstation/buster/securedrop-workstation-viewer_0.1.1+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-viewer_0.1.1+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5dd5e3e10d202cbf90639988543ae8ed979b97b82283a0e4dfa91620301470db
-size 1636


### PR DESCRIPTION
## Status

Ready for review, but needs manual intervention on the apt-test server

## Description of changes
* Remove buster repository configuration from reprepro
* Remove buster packages

On the repository itself, we need to run something like
```
$ reprepro removematched buster '*'
$ reprepro clearvanished
```

Marking as a draft so this can be reviewed, but not yet merged.
