### PR TITLE
add securedrop-client 0.9.0-rc1 package

### DIFF
--- a/workstation/bullseye/securedrop-client_0.9.0-rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-client_0.9.0-rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e3772e29eaf372549e233c23e6a3cd2f9817b13daf491497df189a634281dfd
+size 4116756


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Cross-link to changes made in https://github.com/freedomofpress/securedrop-builder/pull/421
- [x] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/86eaa7f596902e4d74c232aad97787ab27230a0d
- [x] hashes in build log match package hash.
