### PR TITLE
Add securedrop-client 0.9.0-rc2 package

### DIFF
--- a/workstation/bullseye/securedrop-client_0.9.0-rc2+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-client_0.9.0-rc2+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a20e95b518e2044bad5dcbd05fb38629b204d1724db285d039128578de26a522
+size 4116844


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Cross-link to changes made in https://github.com/freedomofpress/securedrop-builder/pull/424
- [x] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/61c3b0e23f9e8c84792c9f0035c20e69d5cf3552
- [x] package hash in build log matches the hash of the PR package.
