### PR TITLE
Added securedrop-client 0.9.0-rc3 package

### DIFF
--- a/workstation/bullseye/securedrop-client_0.9.0-rc3+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-client_0.9.0-rc3+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f4c5b6afb826b9e45cb80e69eff190f9f8efbfe8f3d9b9baae18cb2b4bd351d
+size 4117128


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/b8034562201a51be84a851f11d2fd923347900ce
- [ ] package hashes match those in the build log.

