### PR TITLE
Add securedrop-proxy 0.4.1~rc1

### DIFF
--- a/workstation/bullseye/securedrop-proxy_0.4.1~rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-proxy_0.4.1~rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5b55085446d8da7e0fd00f4cce00f579e5250bf0af0c2661ba6ba262ac41bc2
+size 1229436


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-proxy/issues/116>.

## Status

Ready for review

## Description of changes

## Checklist
- [x] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder): https://github.com/freedomofpress/securedrop-builder/commit/7a92db4f82d3e2b19273fdfbd0e4ab4d9f3369f7
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/eda3d09aba65e5e29fac0c1b10898fd423b4cfe3

