### PR TITLE
Add securedrop-keyring 0.1.7

### DIFF
--- a/workstation/bullseye/securedrop-keyring_0.1.7+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-keyring_0.1.7+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1ab3f276b5c6a79c0075093beecfefb5fb11ea867ffe988d15100f51c90efc0
+size 4856


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-builder/issues/437>.

## Status

Ready for review

## Description of changes

## Checklist
- [x] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder): https://github.com/freedomofpress/securedrop-builder/commit/3f8eae10edb8b5f5ab5f41e559ce04d44ddcecf5
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/1344c6382a444871ec91e6ce60f4b0bdab56e966

