### PR TITLE
Add securedrop-grsec 5.15.89-2

### DIFF
--- a/core/focal/securedrop-grsec_5.15.89-grsec-securedrop-2_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.89-grsec-securedrop-2_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d71105a19fa2b2e9a38039ffa917f4c6f635d7f5490d76b81024b89fe5387ae
+size 3012

--- a/core/focal/securedrop-grsec_5.15.98-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.98-1-grsec-securedrop-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2d50860cef1a4ee898bac57b4d5f3c041192d922c420d6593461c3768870db8
-size 3056


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Fixes https://github.com/freedomofpress/securedrop/issues/6789
Add securedrop-grsec 5.15.89-2, see https://github.com/freedomofpress/securedrop/issues/6789 for more details on how the package was constructed and test plan for it. 5.15.98-1 is removed since it's a higher version and it was buggy and we're not going to be shipping that kernel version anymore.

## Checklist
- [ ] Build has been independently reproduced/verified
- [ ] Cross-link to changes made in [kernel-builder](https://github.com/freedomofpress/kernel-builder): https://github.com/freedomofpress/kernel-builder/commit/79847811a0a4c227442ef234fa6c610e5be01f14
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/b0c20323da3e1da5e1cac1dab9b6be8a3646b47e

## Post-merge notes

After this is merged, manual intervention will be needed on the apt-test server since we need to override the higher versioned package, I'll take care of that when it's time.