### PR TITLE
Add securedrop-keyring-0.2.0

### DIFF
--- a/workstation/bullseye/securedrop-keyring_0.2.0+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-keyring_0.2.0+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:378548f323dfc9770a13612c1f10c03b373582026fdb4a44fef3949685585785
+size 6028


### PR DESCRIPTION
## Status

Ready for review

## Description of changes
Add securedrop-keyring-0.2.0 (note: built from a prod-signed tag and not built with rc number. Anticipating promoting to prod.) 
Towards https://github.com/freedomofpress/securedrop-builder/issues/443

## Checklist
- [x] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder): https://github.com/freedomofpress/securedrop-builder/releases/tag/securedrop-keyring-0.2.0
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/0dde13c1965eab1899f1caec2a41fc2bcc409e94

