### PR TITLE
Add SecureDrop 2.6.0-rc1

### DIFF
--- a/core/focal/securedrop-app-code_2.6.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.6.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6f343c307769aa89c9c4c862104fb5622fa2d81e14426ef679c833d23548e21
+size 13519312

--- a/core/focal/securedrop-config_2.6.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-config_2.6.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b53821a1452ba5b067ccc990118f1dbb778ce9c825489abc2473c92597491902
+size 4200

--- a/core/focal/securedrop-keyring_0.2.1+2.6.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.1+2.6.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87f7cf14aa6701fa5af19d25493c35d942d5239d3eebafa931e34cbb3bd7d3ce
+size 5280

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.6.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.6.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fac16eff458745b8d1a913b7bf9d591ff31b4c95599154295f155ba374ddcb43
+size 4884

--- a/core/focal/securedrop-ossec-server_3.6.0+2.6.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.6.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8638383e39fd01d28bc7942fbe36d65fc15a984979ac248221d59c08064c2025
+size 8532


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Refs <https://github.com/freedomofpress/securedrop/issues/6798>.

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).: https://github.com/freedomofpress/build-logs/commit/6c42ed029c7fc6c901041c338b7911cf3250212f

