### PR TITLE
added securedrop 2.6.0-rc2 debs

### DIFF
--- a/core/focal/securedrop-app-code_2.6.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.6.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed85b1b28bedd86ab6d023926dbc8da54b7fdbc771e5aa83e0a1469335ac72cd
+size 13602400

--- a/core/focal/securedrop-config_2.6.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-config_2.6.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bb1f6baf370613cf3b6c5095a86ef6d99544ed7fdec2fa7b7d8519a4819dead
+size 4200

--- a/core/focal/securedrop-keyring_0.2.1+2.6.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.1+2.6.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34b29df3750e6014e2080ca5d3f11b30ab8d1a0118dbbfc2e90bcc4af67db8e2
+size 5288

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.6.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.6.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1258bbcb76ff70840917bb1545e2cf5611149fdc6c1483fc2235d11d1d23b51
+size 4892

--- a/core/focal/securedrop-ossec-server_3.6.0+2.6.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.6.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bb6d71982510e469af6110973ca7632684bd38a000f76fa982f908de588c1b6
+size 8540


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of changes

## Checklist
- [x] Build logs have been committed in https://github.com/freedomofpress/build-logs/commit/0611b2b290162abbbf12ec86ffe33b4bccdb6b13
