### PR TITLE
Add securedrop-grsec-5.15.120-1 and securedrop-workstation-grsec-5.15.120-1

### DIFF
--- a/core/focal/linux-headers-5.15.120-1-grsec-securedrop_5.15.120-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.120-1-grsec-securedrop_5.15.120-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3045cd4c04f3f3b2fd4c757a5e9ce1858b8f3298f77c761fc0f04099aae1f0d
+size 24917552

--- a/core/focal/linux-image-5.15.120-1-grsec-securedrop_5.15.120-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.120-1-grsec-securedrop_5.15.120-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f02cb9ec54e14e0cc2f9561b907d2132ce4fbda7d18746f43b76fe059d3790b
+size 57410660

--- a/core/focal/securedrop-grsec_5.15.120-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.120-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f84d08836601f95a3175e9c80bbb746060fcabec2c70268fccf81dc040cc5784
+size 3020

--- a/workstation/bullseye/linux-headers-5.15.120-1-grsec-workstation_5.15.120-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-headers-5.15.120-1-grsec-workstation_5.15.120-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7481598e58079c0da0eafd271b9e4ea506d20154fb0d3c678501067627347746
+size 24942980

--- a/workstation/bullseye/linux-image-5.15.120-1-grsec-workstation_5.15.120-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-image-5.15.120-1-grsec-workstation_5.15.120-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2d1160980e8ae56782ec21292714bff5d303b31f80b3aafd9ad0147fe8172f8
+size 46444988

--- a/workstation/bullseye/securedrop-workstation-grsec_5.15.120-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/securedrop-workstation-grsec_5.15.120-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a140e72f86300d14512e04564151f66937a5440324b1b3375221c73b045b09d9
+size 2444


### PR DESCRIPTION
## Status

Work in progress

## Description of changes

Refs https://github.com/freedomofpress/securedrop/issues/6887
Refs https://github.com/freedomofpress/securedrop-workstation/issues/907

## Checklist
- [ ] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder) : N/A
- [x] Artifacts uploaded to s3
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): [workstation build logs](https://github.com/freedomofpress/build-logs/commit/774b2854000d303bd80608b02b12a3ace0923656), [core build logs](https://github.com/freedomofpress/build-logs/commit/721cae05eb998ed9cfedcb3ad7e6723d4300304d)

