### PR TITLE
Add securedrop-grsec_5.15.120-1-grsec-securedrop-2_amd64.deb

### DIFF
--- a/core/focal/securedrop-grsec_5.15.120-1-grsec-securedrop-2_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.120-1-grsec-securedrop-2_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62e36e4b81c89c63c961618800e8797464164e6cdd8dc462602178a21e486938
+size 3024


### PR DESCRIPTION


## Status

Ready for review

## Description of changes

Same as -1, except it adds in a dependency on amd64-microcode (see <https://github.com/freedomofpress/kernel-builder/pull/37>).

## Test plan
Run diffoscope against `securedrop-grsec_5.15.120-1-grsec-securedrop-1_amd64.deb` in the same folder, the packages should be identical except for version and the amd64-microcode dependency:
```
user@dev ~/g/f/s/c/focal> diffoscope securedrop-grsec_5.15.120-1-grsec-securedrop-1_amd64.deb securedrop-grsec_5.15.120-1-grsec-securedrop-2_amd64.deb
--- securedrop-grsec_5.15.120-1-grsec-securedrop-1_amd64.deb
+++ securedrop-grsec_5.15.120-1-grsec-securedrop-2_amd64.deb
├── file list
│ @@ -1,3 +1,3 @@
│  -rw-r--r--   0        0        0        4 2011-06-29 20:23:37.000000 debian-binary
│ --rw-r--r--   0        0        0     1512 2011-06-29 20:23:37.000000 control.tar.xz
│ +-rw-r--r--   0        0        0     1516 2011-06-29 20:23:37.000000 control.tar.xz
│  -rw-r--r--   0        0        0     1316 2011-06-29 20:23:37.000000 data.tar.xz
├── control.tar.xz
│ ├── control.tar
│ │ ├── file list
│ │ │ @@ -1,3 +1,3 @@
│ │ │  drwxr-xr-x   0 root         (0) root         (0)        0 2011-06-29 20:23:37.000000 ./
│ │ │ --rw-r--r--   0 root         (0) root         (0)      587 2011-06-29 20:23:37.000000 ./control
│ │ │ +-rw-r--r--   0 root         (0) root         (0)      604 2011-06-29 20:23:37.000000 ./control
│ │ │  -rwxr-xr-x   0 root         (0) root         (0)     2032 2011-06-29 20:23:37.000000 ./postinst
│ │ ├── ./control
│ │ │ @@ -1,13 +1,13 @@
│ │ │  Package: securedrop-grsec
│ │ │  Source: linux-upstream
│ │ │ -Version: 5.15.120-1-grsec-securedrop-1
│ │ │ +Version: 5.15.120-1-grsec-securedrop-2
│ │ │  Architecture: amd64
│ │ │  Maintainer: SecureDrop Team <securedrop@freedom.press>
│ │ │  Installed-Size: 15
│ │ │ -Depends: linux-image-5.15.120-1-grsec-securedrop, intel-microcode, paxctld, linux-image-5.15.89-grsec-securedrop
│ │ │ +Depends: linux-image-5.15.120-1-grsec-securedrop, intel-microcode, amd64-microcode, paxctld, linux-image-5.15.89-grsec-securedrop
│ │ │  Section: admin
│ │ │  Priority: optional
│ │ │  Homepage: https://securedrop.org/
│ │ │  Description: Metapackage providing a grsecurity-patched Linux kernel for use
│ │ │   with SecureDrop. Depends on the most recently built patched kernel maintained
│ │ │   by FPF. Package also includes sysctl and PaX flags calls for GRUB.
```

## Checklist
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/e1d72c05657f1332415ee9105deeaa02726818a2

