### PR TITLE
Add Linux 5.15.123 packages

### DIFF
--- a/core/focal/linux-headers-5.15.123-1-grsec-securedrop_5.15.123-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.123-1-grsec-securedrop_5.15.123-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc994fb29e6c15ab775d9b0cfd5ba14511f43daae3a9ffea5d21978fa01bfa0f
+size 24957500

--- a/core/focal/linux-image-5.15.123-1-grsec-securedrop_5.15.123-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.123-1-grsec-securedrop_5.15.123-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9389999c07813850cada36784b9fba4606c2f25ce0aa1eabd8540c0038e0cb6
+size 57411424

--- a/core/focal/securedrop-grsec_5.15.123-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.123-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d44f5d25eabba1c94756dcd61b9bcc0bbe7b4206581f7c24d6c12f75af1b2255
+size 3016

--- a/workstation/bullseye/linux-headers-5.15.123-1-grsec-workstation_5.15.123-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-headers-5.15.123-1-grsec-workstation_5.15.123-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef1a38504be12066eea9f896474980ac8de5bb405d43ab630a57b4e5ddc2c1e8
+size 24909128

--- a/workstation/bullseye/linux-image-5.15.123-1-grsec-workstation_5.15.123-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-image-5.15.123-1-grsec-workstation_5.15.123-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:faf40a1376c07a909dab362683f91521c6cc5d83a872f63dd92c6be4b6bda888
+size 46489140

--- a/workstation/bullseye/securedrop-workstation-grsec_5.15.123-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/securedrop-workstation-grsec_5.15.123-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97ef34c6fc8cc9f7f75a2910ce7384e4c5de93a8e974c983584ad9d59c00406b
+size 2444


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Refs <https://github.com/freedomofpress/securedrop/issues/6906>.
Refs <https://github.com/freedomofpress/securedrop-workstation/issues/911>.

## Checklist
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/1cc3aa13481871a04bc987737c24c93cf282102a

