### PR TITLE
add Linux 5.15.130 packages

### DIFF
--- a/core/focal/linux-headers-5.15.130-1-grsec-securedrop_5.15.130-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.130-1-grsec-securedrop_5.15.130-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d1e2be016fcc0eebcbad899939b0ce7fb29b828f14e0b15b0b2cdd720d7e9c7
+size 24949940

--- a/core/focal/linux-image-5.15.130-1-grsec-securedrop_5.15.130-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.130-1-grsec-securedrop_5.15.130-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea4153436cf2ee7d2b0a2ecf2f99d56b4cd8f8ea875efff22e4fd91a4f3b3e09
+size 57424896

--- a/core/focal/securedrop-grsec_5.15.130-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.130-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53de2daaf3d2fce3d363e31c2c3b36475036452dc887c91ee918362704b3625f
+size 3024

--- a/workstation/bullseye/linux-headers-5.15.130-1-grsec-workstation_5.15.130-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-headers-5.15.130-1-grsec-workstation_5.15.130-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03e0439e1d3dc31bf23ee08e3ffb7f72f041281875dcd9a016e7fede0903de58
+size 24902488

--- a/workstation/bullseye/linux-image-5.15.130-1-grsec-workstation_5.15.130-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-image-5.15.130-1-grsec-workstation_5.15.130-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5bce310e1231464aa17a711981bc5f654f399232d321c641dfe4fb0243803
+size 46511944

--- a/workstation/bullseye/securedrop-workstation-grsec_5.15.130-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/securedrop-workstation-grsec_5.15.130-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efe42a0be4251018ec30eaf72596f389742a619d5c4a3a733eac81ab187652aa
+size 2444


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Towards:
- freedomofpress/securedrop#6938
- freedomofpress/securedrop-workstation#916

## Checklist
- [ ] CI passes.
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): freedomofpress/build-logs@86e1bb69cabd3bb1e2a98e8cb6dc8988ea848914