### PR TITLE
add Linux 5.15.131 packages

### DIFF
--- a/core/focal/linux-headers-5.15.131-1-grsec-securedrop_5.15.131-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.131-1-grsec-securedrop_5.15.131-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19917c65902f6912c2a79727388896189b1c8c8729153f42306214fdec3a4773
+size 24913044

--- a/core/focal/linux-image-5.15.131-1-grsec-securedrop_5.15.131-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.131-1-grsec-securedrop_5.15.131-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d79067cb30dfe63eb7e4d248b209de6c298a4310b3f8fc5122d6084ac40134bd
+size 57415148

--- a/core/focal/securedrop-grsec_5.15.131-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.131-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecdb20f5af8a97dd0c4cb23800c9de07523462ebebf7746eacea1d823c60f5ed
+size 3016

--- a/workstation/bullseye/linux-headers-5.15.131-1-grsec-workstation_5.15.131-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-headers-5.15.131-1-grsec-workstation_5.15.131-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c75c72bb3a1bd3f094999410cee06fe42dded674afc9c4abe8a55dbcc456268
+size 24926240

--- a/workstation/bullseye/linux-image-5.15.131-1-grsec-workstation_5.15.131-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-image-5.15.131-1-grsec-workstation_5.15.131-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6c826c732140f83b0512d768fd68efcf835e042317540cc7385b72358b19e00
+size 46481292

--- a/workstation/bullseye/securedrop-workstation-grsec_5.15.131-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/securedrop-workstation-grsec_5.15.131-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cc20281737513cd008a3d8f7ec25a2885bd8ac267deccf5a62f95a0ba1e8270
+size 2444


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Originally [intended][1] just to rebuild #202 with
freedomofpress/kernel-builder#38, this also moved us from v5.15.30 to v5.15.131.

Towards:
- freedomofpress/securedrop#6938
- freedomofpress/securedrop-workstation#916

[1]: https://github.com/freedomofpress/securedrop/issues/6938#issuecomment-1709126141

## Checklist
- [ ] CI passes.
- [ ] Manual verification confirms that freedomofpress/kernel-builder#38 took effect, e.g.:

    ```sh-session
    user@sd-dev:~/securedrop-apt-test$ debdiff core/focal/securedrop-grsec_5.15.130-1-grsec-securedrop-1_amd64.deb core/focal/securedrop-grsec_5.15.131-1-grsec-securedrop-1_amd64.deb 
    File lists identical (after any substitutions)

    Control files: lines which differ (wdiff format)
    ------------------------------------------------
    Depends: [-linux-image-5.15.130-1-grsec-securedrop,-] {+linux-image-5.15.131-1-grsec-securedrop,+} intel-microcode, amd64-microcode, [-paxctld, linux-image-5.15.89-grsec-securedrop-] {+paxctld+}
    Version: [-5.15.130-1-grsec-securedrop-1-] {+5.15.131-1-grsec-securedrop-1+}
    ```

- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): freedomofpress/build-logs@c2137c0afb3999193875e612a2ff9ee621d875aa