### PR TITLE
Add 5.15.135 server and workstation grsec kernels

### DIFF
--- a/core/focal/linux-headers-5.15.135-1-grsec-securedrop_5.15.135-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.135-1-grsec-securedrop_5.15.135-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ade07e129576217e257f3f5764f917dc1783fe647bdb2bee314d70a3e5b898b
+size 25006584

--- a/core/focal/linux-image-5.15.135-1-grsec-securedrop_5.15.135-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.135-1-grsec-securedrop_5.15.135-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14d4e269226305166a0775af0a3797e9fd5cba5ac99ff789f207d568338862df
+size 57428584

--- a/core/focal/securedrop-grsec_5.15.135-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.135-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ddafce863ed859a87184ee77bd5dd9fc90e5ca5eef8afa3c5d62f0b3b0d7376
+size 3016

--- a/workstation/bullseye/linux-headers-5.15.135-1-grsec-workstation_5.15.135-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-headers-5.15.135-1-grsec-workstation_5.15.135-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9de83b8ffafcb0078797870d24d24e93d29f1f425aa4d4d537480a7a7cd7aae5
+size 24931092

--- a/workstation/bullseye/linux-image-5.15.135-1-grsec-workstation_5.15.135-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-image-5.15.135-1-grsec-workstation_5.15.135-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1644135b0c6d19b1de6d2e2a30c9b0b61309ef8c0db9e738d45192bba9c9a9f0
+size 46527488

--- a/workstation/bullseye/securedrop-workstation-grsec_5.15.135-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/securedrop-workstation-grsec_5.15.135-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:739ff44ccf8c5f3acc5f9438a69ea504dd84d4abe9ff34ba61d33a7425dcd316
+size 2444


### PR DESCRIPTION
## Status

Towards [#6966](https://github.com/freedomofpress/securedrop/issues/6966)
Ready for review 
- adds grsecurity-patched linux 5.15.135 kernels for securedrop core and workstation.

## Checklist
- [x] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/43d7dbe0e11bdc6c3f278f61eda7915d794ddc6f

