### PR TITLE
Add Securedrop 2.7.0~rc2 Debian packages

### DIFF
--- a/core/focal/securedrop-app-code_2.7.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.7.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8c5abe35cc64562699b7980f981dfbb9ef065210b46e25aef3fed298e87d1b4
+size 14409416

--- a/core/focal/securedrop-config_2.7.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-config_2.7.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7655410924163b9f79be02fb848e1549abd46bb5dbea631df5f410ec8227d07
+size 4244

--- a/core/focal/securedrop-keyring_0.2.1+2.7.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.1+2.7.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dfb82f01b300309c00b9c7f83fa24f1da10330de1254efcad20e499cd2d8d71
+size 5328

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.7.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.7.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f941385f2cd8ff84240a4dc1a54dcf0aacb092866d289c5e4bbad70949dfe74
+size 4892

--- a/core/focal/securedrop-ossec-server_3.6.0+2.7.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.7.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d116c4c154e7d9db933deaf7d8ee07c834ee40edebea2fbdaa2cb61984107e66
+size 8616


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/975772a6a684613094dcf01cf543efe7734fbd8e
- [x] Correct tag was used for build
