### PR TITLE
Run clean-old-packages on push

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,29 @@
+name: Cleanup
+on:
+  push:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+    clean-old-packages:
+        runs-on: ubuntu-latest
+        container: debian:bookworm
+        steps:
+            - name: Install dependencies
+              run: |
+                apt-get update && apt-get install --yes python3-debian git git-lfs
+            - uses: actions/checkout@v4
+              with:
+                lfs: true
+            - name: Clean old packages
+              run: |
+                git config --global --add safe.directory '*'
+                find core -mindepth 1 -maxdepth 2 -type d | xargs -I '{}' ./scripts/clean-old-packages '{}' 4
+                find workstation -mindepth 1 -maxdepth 2 -type d | xargs -I '{}' ./scripts/clean-old-packages '{}' 4
+                git add .
+                git diff-index --quiet HEAD || git commit -m "Removing old packages"
+                git push origin main

--- a/scripts/clean-old-packages
+++ b/scripts/clean-old-packages
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Clean up old packages, specifying how many to keep
+
+Example:
+    ./scripts/clean-old-packages workstation/buster-nightlies 7
+
+"""
+import argparse
+import functools
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Tuple
+
+from debian import debfile
+
+
+def sort_deb_versions(one: Tuple[str, Path], two: Tuple[str, Path]):
+    """sort two Debian package versions"""
+    status = subprocess.run(['dpkg', '--compare-versions', one[0], 'lt', two[0]])
+    if status.returncode == 1:
+        # false, one is bigger
+        return 1
+    else:
+        # true, two is bigger
+        return -1
+
+
+def fix_name(name: str) -> str:
+    """
+    Linux packages embed the version in the name, so we'd never have multiple
+    packages meet the deletion threshold. Silly string manipulation to drop
+    the version.
+    E.g. "linux-image-5.15.26-grsec-securedrop" -> "linux-image-securedrop"
+    """
+    if name.endswith(('-securedrop', '-workstation')):
+        suffix = name.split('-')[-1]
+    else:
+        return name
+    if name.startswith('linux-image-'):
+        return f'linux-image-{suffix}'
+    elif name.startswith('linux-headers-'):
+        return f'linux-headers-{suffix}'
+    return name
+
+
+def cleanup(data, to_keep: int, sorter):
+    for name, versions in sorted(data.items()):
+        if len(versions) <= to_keep:
+            # Nothing to delete
+            continue
+        print(f'### {name}')
+        items = sorted(versions.items(), key=functools.cmp_to_key(sorter), reverse=True)
+        keeps = items[:to_keep]
+        print('Keeping:')
+        for _, keep in keeps:
+            print(f'* {keep.name}')
+        delete = items[to_keep:]
+        print('Deleting:')
+        for _, path in delete:
+            print(f'* {path.name}')
+            path.unlink()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Cleans up old packages"
+    )
+    parser.add_argument(
+        "directory",
+        type=Path,
+        help="Directory to clean up",
+    )
+    parser.add_argument(
+        "keep",
+        type=int,
+        help="Number of packages to keep"
+    )
+    args = parser.parse_args()
+    if not args.directory.is_dir():
+        raise RuntimeError(f"Directory, {args.directory}, doesn't exist")
+    print(f'Only keeping the latest {args.keep} packages')
+    debs = defaultdict(dict)
+    for deb in args.directory.glob('*.deb'):
+        control = debfile.DebFile(deb).control.debcontrol()
+        name = fix_name(control['Package'])
+        debs[name][control['Version']] = deb
+
+    cleanup(debs, args.keep, sort_deb_versions)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes
Instead of having each job and script be responsible for cleaning up, let's have CI trigger cleanup on every push into the main branch. The clean-old-packages script is copied from securedrop-builder with the RPM parts removed.

Fixes #211.