### PR TITLE
Add SecureDrop 2.8.0-rc1

### DIFF
--- a/core/focal/securedrop-app-code_2.8.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.8.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fb0efaea885ab3b2d60b2136d656afcb00dc1ab289dea3b82befde1d77a61a4
+size 14446852

--- a/core/focal/securedrop-config_2.8.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-config_2.8.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28654db988a8c4b8cd68da0975dabc25d865c62a2eba7a8c1c5015bd7b9a8caf
+size 4268

--- a/core/focal/securedrop-keyring_0.2.1+2.8.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.1+2.8.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04c4481875d6d34f3c3804dc78768344f88f308fe8261bf9daf736300d70c76f
+size 5348

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.8.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.8.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0b15770d415dcb54a54af1f0199abbd8b5d588591172b22c1e2c96128aaa8c4
+size 4912

--- a/core/focal/securedrop-ossec-server_3.6.0+2.8.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.8.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49ee21dccb89e24efb84617b86ec17fd411ef1a3ccc6bcf1a80ebdc5a7718803
+size 8640


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

Refs <https://github.com/freedomofpress/securedrop/issues/7121>.

## Checklist
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/44d2eb627dc3c06f798621478aae711ad64cf3a4

