### PR TITLE
Add securedrop-client 0.10.0-rc1

### DIFF
--- a/workstation/bullseye/securedrop-client_0.10.0~rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-client_0.10.0~rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d09890efa1309c50950aaa2f335a6c2cd5cbdd27fd87672f0e47d1e94f01ef8
+size 4104116

--- a/workstation/bullseye/securedrop-export_0.10.0~rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-export_0.10.0~rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9da33c3a043734038288783ae253d860c03649d8fa77bcda732633a9cc83b72f
+size 582400

--- a/workstation/bullseye/securedrop-keyring_0.10.0~rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-keyring_0.10.0~rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:810a60cd9a91f3f01e31f5cef26dc7991b70eabdae82c8b51c036e7ad4f56731
+size 8004

--- a/workstation/bullseye/securedrop-log_0.10.0~rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-log_0.10.0~rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bdc6091c0047dbadebdc72e0e13d23d7e709be30d2e090bf05cc68525831157
+size 552612

--- a/workstation/bullseye/securedrop-proxy_0.10.0~rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-proxy_0.10.0~rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:639ff64c8f09232e74e941798fdada9a2adb7224ba5ae7e73956df9f99b198f7
+size 1232796

--- a/workstation/bullseye/securedrop-workstation-config_0.10.0~rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-workstation-config_0.10.0~rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9b931cc71c266c1469a6085a40c0feefe8bbb9f21677cc604e1f33085ea4a4c
+size 7356

--- a/workstation/bullseye/securedrop-workstation-viewer_0.10.0~rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-workstation-viewer_0.10.0~rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f951dacc0bbfc81cb78fa1b1f8a71db7716e347c289bfc7b7177d0c90f01e87d
+size 3604


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Refs <https://github.com/freedomofpress/securedrop-client/issues/1867>.

## Checklist
- [ ] Check out the `0.10.0-rc1` tag and run `make build-debs`, verify you get the same checksums as these packages
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/07ed2328733c2b4bed19ba98a96bfec3288836c6

