### PR TITLE
Add SecureDrop Client 0.10.0-rc2 packages

### DIFF
--- a/workstation/bullseye/securedrop-client_0.10.0~rc2+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-client_0.10.0~rc2+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:babdde86f6b44d9733b54798e024156b7cd96587bb4618cdb3eef741b2a3bf56
+size 4102656

--- a/workstation/bullseye/securedrop-export_0.10.0~rc2+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-export_0.10.0~rc2+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e010548d1a8996fcd1b716016cab6c4baeef3100094981a41453f0742166d9ea
+size 581860

--- a/workstation/bullseye/securedrop-keyring_0.10.0~rc2+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-keyring_0.10.0~rc2+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13767865e6b30cdbc0a6175ea5636a291cb82778921488b990edc4f52d0f86ef
+size 8020

--- a/workstation/bullseye/securedrop-log_0.10.0~rc2+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-log_0.10.0~rc2+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c2775adcb4ee8cc4e001714520b4aa4d5edd3ca715d608d572f9e2f4bf84d15
+size 551772

--- a/workstation/bullseye/securedrop-proxy_0.10.0~rc2+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-proxy_0.10.0~rc2+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64ec875222dbb9ccbd9747c06a2d908fce2da96547d7f58c63038a631989aec3
+size 1232056

--- a/workstation/bullseye/securedrop-workstation-config_0.10.0~rc2+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-workstation-config_0.10.0~rc2+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:399ae35852adad5ac85c7f8c72c83a81af7b5b05c44ea2fccbbf6afa99e4897a
+size 7364

--- a/workstation/bullseye/securedrop-workstation-viewer_0.10.0~rc2+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-workstation-viewer_0.10.0~rc2+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdc70ef7c709a6af945aed485df66d4a667b19765fab674ba22d674add858bcf
+size 3616


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

build-logs pushed in <https://github.com/freedomofpress/build-logs/commit/29d0bc42530a035e9ddd22b0107670b870dfa822>.

Refs <https://github.com/freedomofpress/securedrop-client/issues/1867>.

## Checklist
- [x] Check out the `0.10.0-rc2` tag, run `make build-debs` and verify you get the same checksums
- [x] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder).
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

