### PR TITLE
Add SecureDrop Client 0.10.0-rc3 packages

### DIFF
--- a/workstation/bullseye/securedrop-client_0.10.0~rc3+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-client_0.10.0~rc3+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffcc3bcd997c904cf3eee34ef667df1f77d0f213f48ebebfe48c79e3b1a678ef
+size 4101832

--- a/workstation/bullseye/securedrop-export_0.10.0~rc3+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-export_0.10.0~rc3+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ac82c741fa8d0f71f68e4d36054f0e89bcd44124aa6cc115e6f76e4abcd73d2
+size 582160

--- a/workstation/bullseye/securedrop-keyring_0.10.0~rc3+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-keyring_0.10.0~rc3+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eafd0d780f4854462bb1153e0b2278df46fa53b7e974dc5671bc1a7bc9c7fd19
+size 8036

--- a/workstation/bullseye/securedrop-log_0.10.0~rc3+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-log_0.10.0~rc3+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3fa3c94a887e33c8d9f82ef4f88349b97b32953a4582d92a84eefa4d02ebdfd
+size 551940

--- a/workstation/bullseye/securedrop-proxy_0.10.0~rc3+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-proxy_0.10.0~rc3+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b00296a7d1435372c42d2eea0a5f2037570a19442d07909b7159a030a5b155e
+size 1232160

--- a/workstation/bullseye/securedrop-workstation-config_0.10.0~rc3+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-workstation-config_0.10.0~rc3+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99e5ae011aa2ca5441c5a659ac4a7e868168b7e00e1dd631992eaa37c1dd7944
+size 7376

--- a/workstation/bullseye/securedrop-workstation-viewer_0.10.0~rc3+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-workstation-viewer_0.10.0~rc3+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b690ab3fd63f680d9d6a338de256b219afc0f1d6528ea8488dfc3c0734abca3d
+size 3632


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

build-logs pushed in
<https://github.com/freedomofpress/build-logs/commit/59a0e8436e6477a30dcab1f3bbc60192ef8d2456>.

Refs <https://github.com/freedomofpress/securedrop-client/issues/1867>.

## Checklist
- [ ] Check out `0.10.0-rc3` tag, run `make build-debs`, get same checksums as committed here
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

