### PR TITLE
Add workstation 6.6.22 kernel

### DIFF
--- a/workstation/bookworm/linux-headers-6.6.22-grsec-workstation-1_6.6.22-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.22-grsec-workstation-1_6.6.22-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d37b7d8f41e9c56053a2b3d75b5d6343059bd5408b9bacd1e418b70b43d32ce
+size 24602748

--- a/workstation/bookworm/linux-image-6.6.22-grsec-workstation-1_6.6.22-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.22-grsec-workstation-1_6.6.22-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7cfd886f2b972dfd7b21f3ec05e3de16f0a61c36f7ebd0273f9402a2e3b6af5
+size 54657820

--- a/workstation/bookworm/securedrop-grsec_6.6.22-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-grsec_6.6.22-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e25ff941b9d49417330de800be25a724225934b6e8f14f9bb21c7c8b6b08ee2
+size 3020


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

build-logs pushed in
<https://github.com/freedomofpress/build-logs/commit/b30e6ce367ef5b03671044fd42ac04222dbf238e>.

There are a few issues with this kernel, notably the packaging and version numbers are off.

Also I haven't tried it yet.

## Checklist
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).
- [x] Tarball uploaded internally
