### PR TITLE
Copy paxctld from bullseye to bookworm

### DIFF
--- a/workstation/bookworm/paxctld_1.2.5-1_amd64.deb
+++ b/workstation/bookworm/paxctld_1.2.5-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd8b34e622b922204369b54fa331f2c34fcccb34829d7ed5e07b96b697ec8516
+size 278148


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

It hasn't been available in Debian since buster, see b9f9e1f88ca64e19.

## Checklist
- [x] hash matches existing package in bullseye folder
- [ ] ~~Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).~~ n/a

