### PR TITLE
Add 6.6.22-2 workstation Linux kernel

### DIFF
--- a/workstation/bookworm/linux-headers-6.6.22-2-grsec-workstation_6.6.22-2-grsec-workstation-2_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.22-2-grsec-workstation_6.6.22-2-grsec-workstation-2_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f81b10770e066f461b9e53225c18a11a05c3ef998b764f4dd56eee6e241e2fa
+size 24638448

--- a/workstation/bookworm/linux-image-6.6.22-2-grsec-workstation_6.6.22-2-grsec-workstation-2_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.22-2-grsec-workstation_6.6.22-2-grsec-workstation-2_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b56aa17788e3e26a24497262c23a8236ea7fb019ac1d3bd3f93fcd69f02ccb39
+size 54712292

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.22-2-grsec-workstation-2_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.22-2-grsec-workstation-2_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:116bd0b3c7d67328a4bec4220be3fd559af64772dd39b2c50c6a6e45c50e0913
+size 1968


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

* Now with the correct metapackage
* Also more netfilter modules enabled

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/8ed94ce499ebcf3d2d69545d63ed40472eb3feb0

