### PR TITLE
Add Linux 5.15.152 grsec kernels

### DIFF
--- a/core/focal/linux-headers-5.15.152-1-grsec-securedrop_5.15.152-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.152-1-grsec-securedrop_5.15.152-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff83eeaee601e7a4ff181b582af65acced725e77c5f6d717994ff720f9aeb6f6
+size 25325308

--- a/core/focal/linux-image-5.15.152-1-grsec-securedrop_5.15.152-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.152-1-grsec-securedrop_5.15.152-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4a50dfbe1343ab46957d7291bc1667b171453b529bec90812ddf79888172c3c
+size 61733936

--- a/core/focal/securedrop-grsec_5.15.152-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.152-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d174c637cf63ac998ae33fcdad8ffa71ff085be72d4c2a86b37ba2c39c46d80a
+size 3016

--- a/workstation/bullseye/linux-headers-5.15.152-1-grsec-workstation_5.15.152-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-headers-5.15.152-1-grsec-workstation_5.15.152-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6f1c1fc7469b78763d6db3decaea155a642f8e8dd2b0798bca46f0f22755ca0
+size 25278268

--- a/workstation/bullseye/linux-image-5.15.152-1-grsec-workstation_5.15.152-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-image-5.15.152-1-grsec-workstation_5.15.152-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:043274d34d34998b2d1d18ef0109a0e66903a836fb39a918b5d743d3fa76ed2a
+size 49576312

--- a/workstation/bullseye/securedrop-workstation-grsec_5.15.152-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/securedrop-workstation-grsec_5.15.152-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f211bfd0fb56f31226276e873495d9f97d2b435606dd73e2f34d6482d8a3986a
+size 1964


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Add Linux 5.15.152 grsec kernels (core and workstation)
(Note: kernels untested. Source tarballs retained.)

## Checklist
- [ ] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder): n/a
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): [f6dcbbe](https://github.com/freedomofpress/build-logs/commit/f6dcbbe20b3c01c5881e2c8c0c273af934580030)

