### PR TITLE
Add xpp package to Bookworm

### DIFF
--- a/workstation/bookworm/xpp_1.5-cvs20081009-4_amd64.deb
+++ b/workstation/bookworm/xpp_1.5-cvs20081009-4_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61831b5a7cd869a5ce7fc78f8603bcbbe5af936141ec5346810ad75b0a6ad825
+size 53392


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes
Adds `xpp` package under bookworm as well as bullseye, to allow for installation of the current securedrop-export package.

## Checklist
- [ ] deb hash in `workstation/bookworm` matches the existing `workstation/bullseye` version.

