### PR TITLE
Add Linux 6.6.25 for workstation

### DIFF
--- a/workstation/bookworm/linux-headers-6.6.25-1-grsec-workstation_6.6.25-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.25-1-grsec-workstation_6.6.25-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88eaf74d7bbe36252d7258f07f1ee0b41760cb08f38e4f452c2b435fa3814f37
+size 24659728

--- a/workstation/bookworm/linux-image-6.6.25-1-grsec-workstation_6.6.25-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.25-1-grsec-workstation_6.6.25-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b49be0c68d40ba48649cc44aab7e7aac1b6c2c0c0966ca91e96e6e60fc5d9e9
+size 54699216

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.25-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.25-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feeebebd11a37dc667c6c3b2d89c4616a8d197915932f6a20284d4c78d248f2c
+size 1924


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Notably includes the `uname -r` version fix.

## Checklist
- [ ] Tarball has been uploaded internally
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/45dd1dd2b38d00a40b2476b91057eb5488f72859

