### PR TITLE
Fix path to new-tor-issue script

### DIFF
--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -39,4 +39,4 @@ jobs:
                 git add core/focal/*.deb
                 # If there are changes, diff-index will fail, so we commit and push
                 git diff-index --quiet HEAD || (git commit -m "Automatically updating Tor packages" \
-                    && git push origin main && ../scripts/new-tor-issue)
+                    && git push origin main && ./scripts/new-tor-issue)


### PR DESCRIPTION

## Status

Ready for review

## Description of changes
Our cwd is the root of this Git repository, so we don't need to go up one level.

See failure in https://github.com/freedomofpress/securedrop-apt-test/actions/runs/8671817813/job/23781419721

## Checklist
- [ ] visual review

