### PR TITLE
Add 6.6.28 workstastation grsec kernels

### DIFF
--- a/workstation/bookworm/linux-headers-6.6.28-1-grsec-workstation_6.6.28-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.28-1-grsec-workstation_6.6.28-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2665070be86895536e79f43d0e149b020a85fe8e558f588e20793760606a9cc1
+size 24644408

--- a/workstation/bookworm/linux-image-6.6.28-1-grsec-workstation_6.6.28-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.28-1-grsec-workstation_6.6.28-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af82933d8252ce98001efd9c94882bfa1ca3584e5aba994338f866e8fe0a1de1
+size 54907620

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.28-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.28-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8113204b5a5b7613fcf9d4368b88f62175f8ef1ebf403b7fe4addab9ac9f867
+size 1940


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Add 6.6.28 grsec kernels (workstation bookworm)
See https://github.com/freedomofpress/kernel-builder/pull/45

## Checklist
- [x] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder):  see ongoing PR https://github.com/freedomofpress/kernel-builder/pull/45
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/ce00324f6f53f744864faf379f3ec193a28f1bbc
- [ ] Source tarball has been uploaded (yes)

