### PR TITLE
Add workstation grsec 6.2.28-2 kernels

### DIFF
--- a/workstation/bookworm/linux-headers-6.6.28-2-grsec-workstation_6.6.28-2-grsec-workstation-2_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.28-2-grsec-workstation_6.6.28-2-grsec-workstation-2_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c2dacd38174c8a3df00c5ddaabd09168e8e253b348aeebdf99423a8212f0b5f
+size 24680280

--- a/workstation/bookworm/linux-image-6.6.28-2-grsec-workstation_6.6.28-2-grsec-workstation-2_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.28-2-grsec-workstation_6.6.28-2-grsec-workstation-2_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bc66e59e230c6cbe026fa8ef200bc90d614fd1d60bf4f7d0fce586556126125
+size 54927160

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.28-2-grsec-workstation-2_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.28-2-grsec-workstation-2_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d28589471f68ee5ca25ac986f096cb8e01efd594539a7a332023f6dc4afa15e
+size 1948


### PR DESCRIPTION
## Status

Ready for review

## Description of changes
Rebuilt 6.6.28 workstation grsec kernels that include pre-depends on qubes-kernel-vm support.
Refs https://github.com/freedomofpress/kernel-builder/pull/45/

## Checklist
- [ ] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder): see https://github.com/freedomofpress/kernel-builder/pull/45/
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/227c74b973bc83f36cc3220be2aedbfbd0c6f16f
- [ ] Source tarball has been uploaded
