### PR TITLE
Add Linux 6.6.31 workstation kernels

### DIFF
--- a/workstation/bookworm/linux-headers-6.6.31-1-grsec-workstation_6.6.31-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.31-1-grsec-workstation_6.6.31-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d85a773a25d99a1ecee8e968fa1095894bce167be55688dbb69b4b02fbd9480e
+size 24769248

--- a/workstation/bookworm/linux-image-6.6.31-1-grsec-workstation_6.6.31-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.31-1-grsec-workstation_6.6.31-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7030a75aa700a4892f0f4d55f16da0bbc33820f504f5d2707b221dc4be9178df
+size 54948212

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.31-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.31-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15b376e0e51a1242c533276e03a1d8236306036829650a20df202cf8e13affd0
+size 1948


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

New workstation 4.2 kernels

## Checklist
- [x] source tarballs have been uploaded internally 
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/0a89bbea1798e83d83bbe8556d1bd98567c2d044

