### PR TITLE
Add server 5.15.160 Linux kernel

### DIFF
--- a/core/focal/linux-headers-5.15.160-1-grsec-securedrop_5.15.160-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.160-1-grsec-securedrop_5.15.160-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ff1bd1cfada0c67123a267a46f54b69ce93b8519be480f2055809c66f9a1dc6
+size 25309480

--- a/core/focal/linux-image-5.15.160-1-grsec-securedrop_5.15.160-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.160-1-grsec-securedrop_5.15.160-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85869f6a2e21a0b6b676deab8e013fe12967310b3a2b7af6f99a8b9be13bac46
+size 61769284

--- a/core/focal/securedrop-grsec_5.15.160-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.160-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8526969366bfbbcd7ea46333e89ed15c24d405a1f44caad42f556567c5db9154
+size 3016


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Note: this was using the patch in https://github.com/freedomofpress/kernel-builder/pull/51.

## Checklist
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/cfe9868b30d4ef86d1932a21a776018d2b9c324d

