### PR TITLE
chore: remove `securedrop-qubesdb` in favor of `securedrop-qubesdb-tools`

### DIFF
--- a/workstation/bookworm-nightlies/securedrop-qubesdb_0.10.1.dev20240602060458+bookworm_all.deb
+++ b/workstation/bookworm-nightlies/securedrop-qubesdb_0.10.1.dev20240602060458+bookworm_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7df20b8733f1f990c0dd67d87145447e4ca3bb19b16d7963bd2b660d1f277fd6
-size 4068

--- a/workstation/bookworm-nightlies/securedrop-qubesdb_0.10.1.dev20240603060452+bookworm_all.deb
+++ b/workstation/bookworm-nightlies/securedrop-qubesdb_0.10.1.dev20240603060452+bookworm_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:426ded8bc367b0fec3df856aa5a76f52297d7ab9fe495ab932bc4afc4533bd2b
-size 4064

--- a/workstation/bookworm-nightlies/securedrop-qubesdb_0.10.1.dev20240603205102+bookworm_all.deb
+++ b/workstation/bookworm-nightlies/securedrop-qubesdb_0.10.1.dev20240603205102+bookworm_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b06497a2901d3dd0f8af85f5fe0e978add9a3816bdfb1e6651f3217aba472eb9
-size 4072

--- a/workstation/bookworm-nightlies/securedrop-qubesdb_0.10.1.dev20240603211144+bookworm_all.deb
+++ b/workstation/bookworm-nightlies/securedrop-qubesdb_0.10.1.dev20240603211144+bookworm_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc54319d7c0fcce84c1701a815ef0d65577fa9b2441ebc2c6071eca4e39de255
-size 4068


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

freedomofpress/securedrop-client#2051 renamed `securedrop-qubesdb` to `securedrop-qubesdb-tools`.  This removes the orphaned `securedrop-qubesdb` packages.