### PR TITLE
Add 0.11.0-rc1Bookworm  client packages

### DIFF
--- a/workstation/bookworm/securedrop-client_0.11.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-client_0.11.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:335a310ba5a68b2adc43d316ceb8429f7b5449e969f76ac732d7379cf61efe3e
+size 4951740

--- a/workstation/bookworm/securedrop-export_0.11.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_0.11.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a617040195ced3a81d9d5fa0ae13c2ee7b269fb38aa3477e90d911e2d007b152
+size 1666636

--- a/workstation/bookworm/securedrop-keyring_0.11.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_0.11.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66b21d3c5cf0194c2b703f4b650f4d43848af9f551ade786e47a9171230e94d7
+size 9952

--- a/workstation/bookworm/securedrop-log_0.11.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_0.11.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d796f8998d5cf08446726c7bf28f887beccb18c4596bbd30b48b6f6f9b250c5
+size 1637000

--- a/workstation/bookworm/securedrop-proxy_0.11.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_0.11.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ca4e39a3ea02afd5f3ce6b50696a89719a60fba4838509b7cbef8f0bfc06ce5
+size 1045912

--- a/workstation/bookworm/securedrop-qubesdb-tools_0.11.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-qubesdb-tools_0.11.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27057e25625f8da08523573234f3429e13c2e3c6dd3ceb587f7b298a6d0bddf3
+size 4080

--- a/workstation/bookworm/securedrop-whonix-config_0.11.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-whonix-config_0.11.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3a17962ff7b028e6847b504d86be3270be4ce052dc3ed4ae86584e58392b020
+size 4548

--- a/workstation/bookworm/securedrop-workstation-config_0.11.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_0.11.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:596eb5c130b4d64de6167dd7c39e1bea6e6cc9ae77b324e4a89a22293bae641c
+size 9428

--- a/workstation/bookworm/securedrop-workstation-viewer_0.11.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_0.11.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb027b38f96ca70778326de3689980846429b9395aa204a0b1a9c234f0fef5a1
+size 3648


### PR DESCRIPTION
## Status

Ready for review 
## Description of changes

Adds bookworm securedrop-client packages.

## Checklist
- [ ] Cross-link to changes made in https://github.com/freedomofpress/securedrop-builder/releases/tag/securedrop-client-0.11.0-rc1 
- [x] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/fd71da226e8e08eefdb96e2f6600196ba5f67ebe

