### PR TITLE
Add securedrop-keyring-0.10.2-rc1

### DIFF
--- a/workstation/bullseye/securedrop-keyring_0.10.2~rc1+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-keyring_0.10.2~rc1+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d520364d85a28fd2e34ae5a45fb3602e26708abe9ed364a6e594f6005084a360
+size 10204


### PR DESCRIPTION
## Status

Ready for review

Refs https://github.com/freedomofpress/securedrop-client/issues/2049

## Description of changes
Adds only the securedrop-keyring package from 0.10.2-rc1 build.

## Checklist
- [x] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder): we built from https://github.com/freedomofpress/securedrop-builder/releases/tag/securedrop-client-0.10.2
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs) : [1f65f48 ](https://github.com/freedomofpress/build-logs/commit/1f65f483e30f45af2939db4670224e71d1912f82)
- [x] CI passes

