### PR TITLE
Add SecureDrop Client 0.11.0-rc2

### DIFF
--- a/workstation/bookworm/securedrop-client_0.11.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-client_0.11.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e538747c8fd6575533019619768e2b6e912636fa3aba7fbab53423b90ad95cb
+size 4951296

--- a/workstation/bookworm/securedrop-export_0.11.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_0.11.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f2030367a098c2fab9535f164758b3f9293db222d01a2412ad87ac7c272726a
+size 1666600

--- a/workstation/bookworm/securedrop-keyring_0.11.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_0.11.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b912aca35421220f3da0b2510eac87635287477b44fc473796eb67760e842e2
+size 9960

--- a/workstation/bookworm/securedrop-log_0.11.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_0.11.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c09a7bad06489654b59399dbaf60b65f45bf2b829884deb372b047df011b814
+size 1636712

--- a/workstation/bookworm/securedrop-proxy-dbgsym_0.11.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_0.11.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afdc95e4ebf18eec060285469582bc836627b48f49bbd25f33afba17c803bd3b
+size 10785400

--- a/workstation/bookworm/securedrop-proxy_0.11.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_0.11.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c7cb11b5b26f54198985bd3647d34cff6125da1c68fccd8ec17b97298a2d331
+size 1045832

--- a/workstation/bookworm/securedrop-qubesdb-tools_0.11.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-qubesdb-tools_0.11.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:312172d3ca8491c5161de5064e324d4cc439eae6367804ff8eb35553ff152f3b
+size 4096

--- a/workstation/bookworm/securedrop-whonix-config_0.11.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-whonix-config_0.11.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ea41c1464430c80a99636ee5a038661733a79534d11f3b9b28e7e0cc8a8c062
+size 4556

--- a/workstation/bookworm/securedrop-workstation-config_0.11.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_0.11.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:206d2f4e1a0505ba0259f5252e199733df8cbabed4d69b9a0f2125bc6a15558d
+size 9452

--- a/workstation/bookworm/securedrop-workstation-viewer_0.11.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_0.11.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:627721224361a9d77eaa37014f3ea40b33eee8241069039b2c62fbdde282ce8b
+size 3660


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Refs <https://github.com/freedomofpress/securedrop-workstation/issues/1103>.

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/d21439a5d2eabb0d9111407772cb7ab40763fcb1
- [x] can reproduce the build locally
