### PR TITLE
Add SecureDrop grsec 5.15.166 and SecureDrop Workstation grsec 6.6.50 kernel packages

### DIFF
--- a/core/focal/linux-headers-5.15.166-1-grsec-securedrop_5.15.166-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.166-1-grsec-securedrop_5.15.166-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:422ddd5a19eff28b5a6a3e0f0021a4777880496b76666219b8faad28e256e99c
+size 25365920

--- a/core/focal/linux-image-5.15.166-1-grsec-securedrop_5.15.166-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.166-1-grsec-securedrop_5.15.166-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40565cfbf5ceb5c9d5cc7f2ddf953e1831e530435dd6015304ee6a794427c308
+size 61242900

--- a/core/focal/securedrop-grsec_5.15.166-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.166-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bdc75a980402783b8d373e4da2018fee7e123873f7ae77842a6fd9e80d93d74
+size 3016

--- a/workstation/bookworm/linux-headers-6.6.50-1-grsec-workstation_6.6.50-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.50-1-grsec-workstation_6.6.50-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bfa9edf1c1c1265c23061ed8bbc3689aa673197e3945a31488267ba9a76aa67
+size 24681016

--- a/workstation/bookworm/linux-image-6.6.50-1-grsec-workstation_6.6.50-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.50-1-grsec-workstation_6.6.50-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e265bd74121502ce00a6f9a08516a0f4723ebe49428b38220dce200c8a5adef0
+size 54473668

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.50-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.50-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:696bc26850f4d320e6f166b50368df4af0340a2bf157acbfc4a4208ae435a42f
+size 1948


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder): n/a
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/d93b0a5d6fa91bfba671bd9e43b4f4cd09b72e38
- [x] Source tarballs signed + uploaded 

