### PR TITLE
Configure noble component

### DIFF
--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -8,6 +8,14 @@ SignWith: 83127F68BABB04F3FE9A69AA545E94503FAB65AB
 Update: tor
 
 Origin: SecureDrop
+Codename: noble
+Components: main nightlies
+Architectures: amd64
+ValidFor: 6m
+Description: SecureDrop server packages (noble)
+SignWith: 83127F68BABB04F3FE9A69AA545E94503FAB65AB
+
+Origin: SecureDrop
 Codename: buster
 Components: main nightlies
 Architectures: amd64


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

This just sets up the noble component, so people can later create a `core/noble` folder with debs.

The auto-fetching tor part isn't configured since Tor isn't providing noble packages yet (<https://github.com/freedomofpress/securedrop/issues/7250>).

Refs <https://github.com/freedomofpress/securedrop/issues/7210>.