### PR TITLE
Add SecureDrop 5.15.167 and SecureDrop Workstation 6.6.56 grsec kernels

### DIFF
--- a/core/focal/linux-headers-5.15.167-1-grsec-securedrop_5.15.167-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.167-1-grsec-securedrop_5.15.167-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4fb2e2dc050302169a0491a80ed1abd6224bc6d1a011f098b2f4f2a1f303436
+size 25590936

--- a/core/focal/linux-image-5.15.167-1-grsec-securedrop-dbg_5.15.167-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.167-1-grsec-securedrop-dbg_5.15.167-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ceba0e723fa1aa6cb0b26e003117b11caf05672d851c1a796c17387068a16d8b
+size 798142176

--- a/core/focal/linux-image-5.15.167-1-grsec-securedrop_5.15.167-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.167-1-grsec-securedrop_5.15.167-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4128b6525cac309ef8c1d4726eb3906b88115fb8c1439f385528dec2ac209954
+size 61244680

--- a/core/focal/securedrop-grsec_5.15.167-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.167-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c728016f2be56432eb5bbe8a1a4f0a02af09fbae0aae5ce4a2af1d1f2f31b95
+size 3016

--- a/workstation/bookworm/linux-headers-6.6.56-1-grsec-workstation_6.6.56-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.56-1-grsec-workstation_6.6.56-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b65c07bf53836b5f8e20a070bfbb8e3a9513def1a64d5cd06a434db7974a3009
+size 25061696

--- a/workstation/bookworm/linux-image-6.6.56-1-grsec-workstation-dbg_6.6.56-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.56-1-grsec-workstation-dbg_6.6.56-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8f0bba7cfe7ecc64d70dfae502f7eb58be0c13c294502d83dbca6f1de938eb9
+size 534919668

--- a/workstation/bookworm/linux-image-6.6.56-1-grsec-workstation_6.6.56-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.56-1-grsec-workstation_6.6.56-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19bf01868567b99dc42eff725b81f227a3a29c8c93d227e59b084a60bb75b8b5
+size 54524688

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.56-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.56-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77d958589a58dab4d96bc4e3ca00dd5a1a72be73445236ec7ac60c2afc9dccd2
+size 1948


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] artifacts have been preserved/uploaded (yes)
- [x] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder): n/a
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs):
  - core: [buildinfo](https://github.com/freedomofpress/build-logs/commit/9d7a895c885b2649ec4ec4ab04383668110746f2), [build log](https://github.com/freedomofpress/build-logs/commit/81273e08f87e48f5a640406bb219dafc05ac49dc)
  - workstation:   https://github.com/freedomofpress/build-logs/commit/68207d29b21c9a72cbab0fb11b8507a1e35eea06

