### PR TITLE
Don't upload the dbg kernel packages

### DIFF
--- a/core/focal/linux-image-5.15.167-1-grsec-securedrop-dbg_5.15.167-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.167-1-grsec-securedrop-dbg_5.15.167-1-grsec-securedrop-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ceba0e723fa1aa6cb0b26e003117b11caf05672d851c1a796c17387068a16d8b
-size 798142176

--- a/workstation/bookworm/linux-image-6.6.56-1-grsec-workstation-dbg_6.6.56-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.56-1-grsec-workstation-dbg_6.6.56-1-grsec-workstation-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8f0bba7cfe7ecc64d70dfae502f7eb58be0c13c294502d83dbca6f1de938eb9
-size 534919668


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

While it's nice to have them, they're giant and seem to be causing our package repository server to OOM.

Refs <https://github.com/freedomofpress/infrastructure/issues/5131>.