### PR TITLE
Add Linux 6.6.57 for server on noble

### DIFF
--- a/core/noble/linux-headers-6.6.57-1-grsec-securedrop_6.6.57-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-headers-6.6.57-1-grsec-securedrop_6.6.57-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68deaa362f991d1df272e98364a25c89a8ee94491e955b90c586b26430f1a3cc
+size 25035516

--- a/core/noble/linux-image-6.6.57-1-grsec-securedrop_6.6.57-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-image-6.6.57-1-grsec-securedrop_6.6.57-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:470bd1df1087a681434e9d6c981d643403467cb4de90b614cb53b6395a330dca
+size 70635808

--- a/core/noble/securedrop-grsec_6.6.57-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/securedrop-grsec_6.6.57-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6236dcc6c38c8b166666d02d2b738ad4ec2ebd7439b40825f65c08c7f5ae9200
+size 3016


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Note that this was built using https://github.com/freedomofpress/kernel-builder/pull/54, so that can probably be merged too now.

I tested the kernel on a NUC 10 with noble and it booted.

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/994caf2ba68e194b0c0f6a3f06796774dca1f151
- [x] Tarball uploaded internally

