### PR TITLE
Add paxctld 1.2.6 for noble

### DIFF
--- a/core/noble/paxctld_1.2.6-1_amd64.deb
+++ b/core/noble/paxctld_1.2.6-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b0572222c677321ea39eb0714f5d2e2c6eb3269500b2280556f57af2a826f39
+size 278372


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Downloaded from <https://grsecurity.net/paxctld/paxctld_1.2.6-1_amd64.deb> and verified:

```
gpg: Signature made Wed Sep 25 09:30:02 2024 EDT
gpg:                using RSA key DE9452CE46F42094907F108B44D1C0F82525FE49
gpg: Good signature from "Bradley Spengler (spender) <spender@grsecurity.net>" [unknown]
gpg:                 aka "Bradley Spengler <brad.spengler@grsecurity.net>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: DE94 52CE 46F4 2094 907F  108B 44D1 C0F8 2525 FE49
```

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).: https://github.com/freedomofpress/build-logs/commit/2a2e9ec8429d4a2adcc11a5ef8a80c5033bc79a4 contains buildinfo, but upstream didn't provide a build log
- [x] Download the signature from https://grsecurity.net/download and verify it
