### PR TITLE
Add Linux 6.6.58 server kernels

### DIFF
--- a/core/noble/linux-headers-6.6.58-1-grsec-securedrop_6.6.58-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-headers-6.6.58-1-grsec-securedrop_6.6.58-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ebbca99449b16e0a029c337b1094beffc6b4522a08fdb323c1e37a34783b808
+size 25059876

--- a/core/noble/linux-image-6.6.58-1-grsec-securedrop_6.6.58-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-image-6.6.58-1-grsec-securedrop_6.6.58-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6dd9ef5e80c81a4f0b7d1f2ef104081f1ccc23cdb7e80728a9a44df79b080a6
+size 70760408

--- a/core/noble/securedrop-grsec_6.6.58-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/securedrop-grsec_6.6.58-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee1ab973bb8b08c39cf2ebefde19eb2e117f1e0c867d4abec23be190433307f
+size 3016


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Contains extra netfilter modules for nftables; see https://github.com/freedomofpress/kernel-builder/pull/54.

## Checklist
- [ ] tarball uploaded internally
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).: https://github.com/freedomofpress/build-logs/commit/a5b3e01b8e550ee085ceb05fa26b4b37c47f5183

