### PR TITLE
Import Tor packages for noble too

### DIFF
--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -35,8 +35,10 @@ jobs:
                 REPREPRO_BASE_DIR=repo reprepro --export=never update
 
                 # Move the new packages over, intentionally leaving the old ones around
-                mv repo/pool/main/t/tor/*.deb core/focal/
+                mv repo/pool/main/t/tor/*focal*.deb core/focal/
+                mv repo/pool/main/t/tor/*noble*.deb core/noble/
                 git add core/focal/*.deb
+                git add core/noble/*.deb
                 # If there are changes, diff-index will fail, so we commit and push
                 git diff-index --quiet HEAD || (git commit -m "Automatically updating Tor packages" \
                     && git push origin main && ./scripts/new-tor-issue)

--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -5,7 +5,7 @@ Architectures: amd64
 ValidFor: 6m
 Description: SecureDrop server packages (focal)
 SignWith: 83127F68BABB04F3FE9A69AA545E94503FAB65AB
-Update: tor
+Update: tor-focal
 
 Origin: SecureDrop
 Codename: noble
@@ -14,6 +14,7 @@ Architectures: amd64
 ValidFor: 6m
 Description: SecureDrop server packages (noble)
 SignWith: 83127F68BABB04F3FE9A69AA545E94503FAB65AB
+Update: tor-noble
 
 Origin: SecureDrop
 Codename: buster

--- a/repo/conf/updates
+++ b/repo/conf/updates
@@ -1,4 +1,4 @@
-Name: tor
+Name: tor-focal
 Method: https://deb.torproject.org/torproject.org
 Components: main
 Suite: focal
@@ -7,3 +7,11 @@ Architectures: amd64
 VerifyRelease: 74A941BA219EC810
 ListShellHook: grep-dctrl -e -S '^tor(-geoip)?$' || [ $? -eq 1 ]
 
+Name: tor-noble
+Method: https://deb.torproject.org/torproject.org
+Components: main
+Suite: noble
+GetInRelease: no
+Architectures: amd64
+VerifyRelease: 74A941BA219EC810
+ListShellHook: grep-dctrl -e -S '^tor(-geoip)?$' || [ $? -eq 1 ]


### PR DESCRIPTION


## Status

Ready for review

## Description of changes

The next nightly run will pull them in.

Fixes <https://github.com/freedomofpress/securedrop/issues/7250>.

## Test plan
I've already verified this, but for completeness:

- [x] in a bookworm container, install the `reprepro ca-certificates dctrl-tools` packages and import the gpg keys (`gpg --import repo/conf/updates-keys/*.gpg`)
- [x] then run `REPREPRO_BASE_DIR=repo reprepro --export=never update`, it'll emit warnings but once it finishes, run `ls repo/pool/main/t/tor/` and you should see:
```
root@bd5061c646a3:/src# ls repo/pool/main/t/tor/
tor-geoipdb_0.4.8.13-2~focal+1_all.deb	tor-geoipdb_0.4.8.13-2~noble+1_all.deb	tor_0.4.8.13-2~focal+1_amd64.deb  tor_0.4.8.13-2~noble+1_amd64.deb
```

