### PR TITLE
add SecureDrop Client 0.14.0-rc2 packages

### DIFF
--- a/workstation/bookworm/securedrop-client-dbgsym_0.14.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_0.14.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:003da8bfc250e4398235cbc686c1bdbb242a220a82e263f0e89111ef50432d0b
+size 49712

--- a/workstation/bookworm/securedrop-client_0.14.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_0.14.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f6d7ca25079cd824b8239aa5eda784d175d107ae3882c96f29000068a85b834
+size 4928604

--- a/workstation/bookworm/securedrop-export_0.14.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_0.14.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96837e9491fde657e124fb6cea7dbd00cbe4587d2994fac9df49b03f8e242f5d
+size 1643796

--- a/workstation/bookworm/securedrop-keyring_0.14.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_0.14.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:156cb7219c192c44e1941c497f416263c54895b17e08a3b7c5ba732e05b0243a
+size 9996

--- a/workstation/bookworm/securedrop-log_0.14.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_0.14.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aac65ec020c63e42350b8e18662cc22908d374d67643cade3ec5c586b538a9dc
+size 1611480

--- a/workstation/bookworm/securedrop-proxy-dbgsym_0.14.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_0.14.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb6d77194fae397127bf1d3d8c495f73acc24457bcbeed34f31f9edc199f89c8
+size 10946676

--- a/workstation/bookworm/securedrop-proxy_0.14.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_0.14.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b7ba937707c86990988b114f0a28bae5e3c4117b1774dc13b0d49be1de3e3f4
+size 1043376

--- a/workstation/bookworm/securedrop-qubesdb-tools_0.14.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-qubesdb-tools_0.14.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2762ce13f2557be0ba5c2a8f07789e7fc40bfea4eadb127ddd0c7d981487ad7a
+size 4156

--- a/workstation/bookworm/securedrop-whonix-config_0.14.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-whonix-config_0.14.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad3d79d197fd092bdadcc5bfc56172cda688c4d137147dd7059465134d77489e
+size 4724

--- a/workstation/bookworm/securedrop-workstation-config_0.14.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_0.14.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af4f2050f777566a9726c5c90405e8590cad15633907d6458b6ea83e5d997684
+size 9480

--- a/workstation/bookworm/securedrop-workstation-viewer_0.14.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_0.14.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81985ed1ace5dd53cebfabfc2c0e1b85d8bd8cb5a6a30e5cd32747b1ff69ac95
+size 3700


### PR DESCRIPTION
## Status

Ready for review 
## Description of changes

## Checklist
- [ ] Build metadata has been committed to https://github.com/freedomofpress/build-logs/commit/a84ffe68a5b24a797f35d6fa379b4e42c3b562cd
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
