### PR TITLE
Add server 5.15.172 and 6.6.61 kernels; Add workstation 6.6.61 kernel

### DIFF
--- a/core/focal/linux-headers-5.15.172-1-grsec-securedrop_5.15.172-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.172-1-grsec-securedrop_5.15.172-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:987fee28f1d21febd8168ca769bad1cece1d7da81456a048b021980aae92194b
+size 25603952

--- a/core/focal/linux-image-5.15.172-1-grsec-securedrop_5.15.172-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.172-1-grsec-securedrop_5.15.172-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4ce06a9a245340d7dd6dd96cc8f1b913c5fbdee3160dc1a3c84025111ec45cc
+size 61330720

--- a/core/focal/securedrop-grsec_5.15.172-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.172-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7de480adc03b7f6b1643e50453b01e7b08d6240e95f86a16b27e3dfa3954de3
+size 3304

--- a/core/noble/linux-headers-6.6.61-1-grsec-securedrop_6.6.61-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-headers-6.6.61-1-grsec-securedrop_6.6.61-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edc0aa4834b2a9d6ff621a7bafbb9aeb04e4d57b3838227cf311370d328ceb87
+size 25057784

--- a/core/noble/linux-image-6.6.61-1-grsec-securedrop_6.6.61-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-image-6.6.61-1-grsec-securedrop_6.6.61-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c620a1225b82746fad3c4f0a0e260ec879cc71cbce3df4fe9c76634e6d596943
+size 70730000

--- a/core/noble/securedrop-grsec_6.6.61-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/securedrop-grsec_6.6.61-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1431eda9c614a3d89ca4230c7df79e8407f244375e216d21224c509465556f94
+size 3304

--- a/workstation/bookworm/linux-headers-6.6.61-1-grsec-workstation_6.6.61-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.61-1-grsec-workstation_6.6.61-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a5ba52febd2245ee45cb98f6307bc976fc1b5ed475cd6865829e458f32b6475
+size 25009608

--- a/workstation/bookworm/linux-image-6.6.61-1-grsec-workstation_6.6.61-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.61-1-grsec-workstation_6.6.61-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5074ce5b652689d54047d46c7f06226354af1e440e7e24906916953633732134
+size 54510920

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.61-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.61-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a56605364c198d634e2ec306a0fa9002c25a765b79e14d2acfbc481031289b72
+size 1948


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

This includes the latest changes from kernel-builder, especially https://github.com/freedomofpress/kernel-builder/pull/55 (setting ipv4 sysctl flags on the server).

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs).
  - [x] server: https://github.com/freedomofpress/build-logs/commit/5cb5a8b720afd44a2292c3c63718d5dfdc5a9220
  - [x] workstation: https://github.com/freedomofpress/build-logs/commit/75d3eafa080020d10c6af108590e324bb188a4f5 
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] For kernel packages only: source tarball uploaded internally
