### PR TITLE
Add 5.15.173 and 6.6.62 server kernels

### DIFF
--- a/core/focal/linux-headers-5.15.173-1-grsec-securedrop_5.15.173-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.173-1-grsec-securedrop_5.15.173-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ad63bf9be49c3eabd20b2c804286eca4957eb09fff1a66c22207191ab0d625
+size 25531636

--- a/core/focal/linux-image-5.15.173-1-grsec-securedrop_5.15.173-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.173-1-grsec-securedrop_5.15.173-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e5b94adc6747f283d004ff1f8757a30befbee77fc31be8ae32119c886372915
+size 61356380

--- a/core/focal/securedrop-grsec_5.15.173-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.173-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b352b8d907ab1a4816e24fc3af0b1d426fddf60b65e476a9602c27233adb1a16
+size 3328

--- a/core/noble/linux-headers-6.6.62-1-grsec-securedrop_6.6.62-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-headers-6.6.62-1-grsec-securedrop_6.6.62-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7af775aa8f58d0684885eb59fdd94ab0e9283705e74c5c9f995c667f0eb72e20
+size 25072260

--- a/core/noble/linux-image-6.6.62-1-grsec-securedrop_6.6.62-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-image-6.6.62-1-grsec-securedrop_6.6.62-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e07c1f30853decb3c6d3ad7cd1f208775b0cdc3fb9c4221b34f2a5b860b4155a
+size 70694756

--- a/core/noble/securedrop-grsec_6.6.62-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/securedrop-grsec_6.6.62-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:056015fc26689095e1e1fc809a67ce96a7a7255824fe9ef0a5c0c69940ed5dce
+size 3328


### PR DESCRIPTION


## Status

Ready for review

## Description of changes

These metapackages contain the fix from https://github.com/freedomofpress/kernel-builder/pull/57

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/c68e1492435f8e0c787909b042d8480a96e2fb90
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] For kernel packages only: source tarball uploaded internally
