### PR TITLE
Add SecureDrop 2.11.0-rc1 packages

### DIFF
--- a/core/focal/securedrop-app-code-dbgsym_2.11.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code-dbgsym_2.11.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d3d6e6e5d551dbe9aa59df2179b41a65a180d986bd5919df0a329a56c238c50
+size 1036268

--- a/core/focal/securedrop-app-code_2.11.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.11.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47ec148c14b6961a1d1116e9dfe9c68465fcdf7ab1ac95dd8db8e1a09302843f
+size 14841720

--- a/core/focal/securedrop-config-dbgsym_2.11.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-config-dbgsym_2.11.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af4ef1de1ed3d3572077cd4a7adf9f82e5cb878676714dba15f7e0517f5bc9e2
+size 37064

--- a/core/focal/securedrop-config_2.11.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-config_2.11.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffc62dff1f312065b22ee0ff210de0e392ce00524c63a8c2576fbf9683177f1d
+size 283480

--- a/core/focal/securedrop-keyring_0.2.2+2.11.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.2+2.11.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47ca54328fa8914ef99fbd0530c1be401e4b432bac00c7d8d944815616b880c4
+size 7528

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.11.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.11.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd2815ef3d7061870d07348e1f90e7b5a77546c0a9b2694dfdcb01daa488cb88
+size 4996

--- a/core/focal/securedrop-ossec-server_3.6.0+2.11.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.11.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd5e120fce9be39060cc751375ba8a3211d57a211f4a355709f065913eaa580
+size 8712


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Build metadata has been committed to https://github.com/freedomofpress/build-logs/commit/ac9fdd102a21a347445dec44cf8635a0e15ae9fa
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
