### PR TITLE
Add SecureDrop 2.11.0-rc2 packages

### DIFF
--- a/core/focal/securedrop-app-code-dbgsym_2.11.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code-dbgsym_2.11.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:122571e4769b5803e1d79e5c10a2d6a8a639d7dc9565c83e3929865b81c43542
+size 1036152

--- a/core/focal/securedrop-app-code_2.11.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.11.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad88e1ac8037902aa014b45e48dc457f499e967bf25fbe579a7611ace9a0c07d
+size 14838304

--- a/core/focal/securedrop-config-dbgsym_2.11.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-config-dbgsym_2.11.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbbf79b5314af3b23c7458fa8da9d1dd7bf938dca417cca8658f66a3331d615f
+size 36988

--- a/core/focal/securedrop-config_2.11.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-config_2.11.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67e0391b5ca4017e2c1db57af4cc12110cfc34b6997837f326e976a428991f6c
+size 283436

--- a/core/focal/securedrop-keyring_0.2.2+2.11.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.2+2.11.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3243326a8c7c5684ac1d539ee271de19808bf3fa7507f4f28a2f20060e670d10
+size 7544

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.11.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.11.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4a8402959fe4f39b7bc9b271c00b676e35356d00d1ad80ede7839bfaab7cfb6
+size 5004

--- a/core/focal/securedrop-ossec-server_3.6.0+2.11.0~rc2+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.11.0~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65b6043aee3762ac55b46434351563377614664b18cc8d07845fb4d05387fcd6
+size 8724


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Build metadata has been committed to https://github.com/freedomofpress/build-logs/commit/5a6375652a80b9eef73323a4b7976c187c700311
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
