### PR TITLE
Add OSSEC noble packages

### DIFF
--- a/core/noble/ossec-agent_3.6.0+noble_amd64.deb
+++ b/core/noble/ossec-agent_3.6.0+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80d1e294f821b12e0a7f2b094037551728be58a4915be15aaa0199e111bd83ca
+size 214930

--- a/core/noble/ossec-server_3.6.0+noble_amd64.deb
+++ b/core/noble/ossec-server_3.6.0+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16e17e2d153d8ae2953cc5924225240359fad7959f2da84ce751f2ef66c6aea9
+size 516964


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Built off the 2.11.1 tag.

build metadata pushed into <https://github.com/freedomofpress/build-logs/commit/a671ae7e180096d3f86ddbda330fa28f1730fe04>.

Refs <https://github.com/freedomofpress/securedrop/issues/7411>.

## Checklist
- [ ] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs).
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes

