### PR TITLE
Add focal and noble SecureDrop 2.12.0-rc1 packages

### DIFF
--- a/core/focal/securedrop-app-code-dbgsym_2.12.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code-dbgsym_2.12.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9840e3c9a07dc5fc55a5f06014f67043a90e9da2c76d97a054832d84b120411
+size 1040512

--- a/core/focal/securedrop-app-code_2.12.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.12.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a21533e36634c3ab78f0daf04947604bef2eea93c989eb3f72b1e4e901b7d127
+size 14891940

--- a/core/focal/securedrop-config-dbgsym_2.12.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-config-dbgsym_2.12.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:986313d0d38069d06c19a19aeaf5fc1984d695a5426d616e8a22b20d2b4ffebd
+size 66264

--- a/core/focal/securedrop-config_2.12.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-config_2.12.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d23bcfed56c74bfce7407b989dbdf51640a7affb196201a59a88cd2ba4ddb27
+size 427548

--- a/core/focal/securedrop-keyring_0.2.2+2.12.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.2+2.12.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:722812886bfb0c22ff7a6b535539b1fdbca4c1b8c7dae75bdc960b63560d7625
+size 7556

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.12.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.12.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfb44d584e12a08e686d6972a62e5ff4e87169adb7ae46b0bc4daad7255b5767
+size 5024

--- a/core/focal/securedrop-ossec-server_3.6.0+2.12.0~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.12.0~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:844cbddf6d2420a29eaf21f88083ae723e34fb3dbd743f9149524ed3e5ca6042
+size 8752

--- a/core/noble/securedrop-app-code-dbgsym_2.12.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code-dbgsym_2.12.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7c2fa6bfb477cb3d06b11eb91aa41d0d77887bcaba4a6c986f28a0a9a09c0ed
+size 1000550

--- a/core/noble/securedrop-app-code_2.12.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code_2.12.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fed8af03455681e4dcd9494d2c1760ca726d0ebc77f58d7c759649a4229a8c4
+size 13521360

--- a/core/noble/securedrop-config-dbgsym_2.12.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-config-dbgsym_2.12.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52a0f739ff57b8d9e0959f07a13c171176b3b483058559b431aee74d66413be4
+size 70416

--- a/core/noble/securedrop-config_2.12.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-config_2.12.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf6a98f2295d33604c9bf8f2c9106d6b7eeee44c2c15461e65e85ac68aba44d8
+size 466462

--- a/core/noble/securedrop-keyring_0.2.2+2.12.0~rc1+noble_all.deb
+++ b/core/noble/securedrop-keyring_0.2.2+2.12.0~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65304479fb8ebf25d8cc60c4c98ceeaa129f92888d081ea5a4eeb3201ffbe19f
+size 7352

--- a/core/noble/securedrop-ossec-agent_3.6.0+2.12.0~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-agent_3.6.0+2.12.0~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f84a2e7863b431031c57d21854f9159f9bdc1e83777ab44227c9b42cb13adb66
+size 5012

--- a/core/noble/securedrop-ossec-server_3.6.0+2.12.0~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-server_3.6.0+2.12.0~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b08248d267277776310f889491ee441708ac2e7af1159a64da4c33db7170951a
+size 8832


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Build metadata has been committed to https://github.com/freedomofpress/build-logs/commit/62a499e36c75ae96c94af664764609a0437d98a8
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] ensure both sets of `focal` and `noble` packages are present.

