### PR TITLE
SecureDrop 2.12.0-rc3

### DIFF
--- a/core/focal/securedrop-app-code-dbgsym_2.12.0~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-app-code-dbgsym_2.12.0~rc3+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c07380f572d1c8f14c664ac116b89892353c4ea34132158d1a5cee77e01d938
+size 1039032

--- a/core/focal/securedrop-app-code_2.12.0~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.12.0~rc3+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03975e382c53705c20ac1775c82ee9a9fe6d79642e606ad3904395d751aa8347
+size 14892252

--- a/core/focal/securedrop-config-dbgsym_2.12.0~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-config-dbgsym_2.12.0~rc3+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d05e5ba1168a20c88fc3962b5f48b4b61b976d1e9e61c520ea7941aadc86eba0
+size 66260

--- a/core/focal/securedrop-config_2.12.0~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-config_2.12.0~rc3+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efa52ba6785ca1a6336326d12b7d9b5619935e861aa61beffe343dcd0ccb0a4b
+size 427748

--- a/core/focal/securedrop-keyring_0.2.2+2.12.0~rc3+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.2+2.12.0~rc3+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff05e7d81f909a22c45411de386f7a24a883dcc0e1b32ba3b95d56d09579bc4a
+size 7588

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.12.0~rc3+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.12.0~rc3+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9abb80d60aa0f4916d64008063f720a0d9319d175460cbdfb83f7e02296231b
+size 5056

--- a/core/focal/securedrop-ossec-server_3.6.0+2.12.0~rc3+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.12.0~rc3+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f68a5bad716307b37f59a95f1a20d5bab31dfdc78adecdb91f6fbbebc5df9855
+size 8776

--- a/core/noble/securedrop-app-code-dbgsym_2.12.0~rc3+noble_amd64.deb
+++ b/core/noble/securedrop-app-code-dbgsym_2.12.0~rc3+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6feb2ceab58780ee6390dc68cac2ea9fd2b1392aa155f8a7d023da29a7a35001
+size 1001256

--- a/core/noble/securedrop-app-code_2.12.0~rc3+noble_amd64.deb
+++ b/core/noble/securedrop-app-code_2.12.0~rc3+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c088471412c8f578f5a47278f38ee561431632900efb81948290ede3098d6c04
+size 13522104

--- a/core/noble/securedrop-config-dbgsym_2.12.0~rc3+noble_amd64.deb
+++ b/core/noble/securedrop-config-dbgsym_2.12.0~rc3+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba87fc130ca0ad273381999e726b313a4b6aad102ec7f27d1821265e13c0ef75
+size 70418

--- a/core/noble/securedrop-config_2.12.0~rc3+noble_amd64.deb
+++ b/core/noble/securedrop-config_2.12.0~rc3+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f8d49f3d18cc1159d3e871a16e0687a9af171d2df27e70d0f4d53763fb4f2e6
+size 466626

--- a/core/noble/securedrop-keyring_0.2.2+2.12.0~rc3+noble_all.deb
+++ b/core/noble/securedrop-keyring_0.2.2+2.12.0~rc3+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24e541425920b5a8bb1b1b630c47a948df2702f30654e87957d80be2289e891a
+size 7388

--- a/core/noble/securedrop-ossec-agent_3.6.0+2.12.0~rc3+noble_all.deb
+++ b/core/noble/securedrop-ossec-agent_3.6.0+2.12.0~rc3+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:997181e0e6c87456f1170aabb234ad9e9d5088cc42b4ef9954e8f1fe9097cef0
+size 5030

--- a/core/noble/securedrop-ossec-server_3.6.0+2.12.0~rc3+noble_all.deb
+++ b/core/noble/securedrop-ossec-server_3.6.0+2.12.0~rc3+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7b9b33c600376d5c9d26273b0997af7f878369e76922ecebe5960adbeb3fb03
+size 8860


### PR DESCRIPTION
## Status

Ready for review

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/e2134b49d5dbe65781690e5ec25b445701071dcd
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
    - [x] Focal
    - [x] Noble
- [x] Build locally and compare sha256sum hashes (if reproducible)