### PR TITLE
Add Linux 5.15.179 and 6.6.83 packages

### DIFF
--- a/core/focal/linux-headers-5.15.179-1-grsec-securedrop_5.15.179-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.179-1-grsec-securedrop_5.15.179-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a1bbbcb447213cead4e636c888ac4b6d2fbe5a346616726eca1e6ac2fc72ad4
+size 25620872

--- a/core/focal/linux-image-5.15.179-1-grsec-securedrop_5.15.179-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.179-1-grsec-securedrop_5.15.179-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2543fb3e05a9445b65ca3adc71c44efbd607bdc29a56aa35b82011af730fe8f3
+size 61418740

--- a/core/focal/securedrop-grsec_5.15.179-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.179-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35f064d682c1e545f24bae1ceff695cc7b6e2ef5d93f04808ef5c9ef4cb9ee06
+size 3328

--- a/core/noble/linux-headers-6.6.83-1-grsec-securedrop_6.6.83-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-headers-6.6.83-1-grsec-securedrop_6.6.83-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:978e2b0ec9773a42fb85e9ab1cf229505d82f6a816b90910e00bdae0a0638e6e
+size 25076744

--- a/core/noble/linux-image-6.6.83-1-grsec-securedrop_6.6.83-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-image-6.6.83-1-grsec-securedrop_6.6.83-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0eb31c85aa9454eac4f61c3f0ac63c6f18bb1e75adf5700e52055845d79324f
+size 70756740

--- a/core/noble/securedrop-grsec_6.6.83-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/securedrop-grsec_6.6.83-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1feaa26f8e6cac82fc291d8a150078e8e1cd917ac9b993c71e39900c4d419539
+size 3328

--- a/workstation/bookworm/linux-headers-6.6.83-1-grsec-workstation_6.6.83-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.83-1-grsec-workstation_6.6.83-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1aa8d22b5ab8f388bafb9269d6baac510f109326b1fa50624521e12485f1118
+size 24994048

--- a/workstation/bookworm/linux-image-6.6.83-1-grsec-workstation_6.6.83-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.83-1-grsec-workstation_6.6.83-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0df2838994f834d23fb9bd98ef00a3726e0ac85cf471287af1cb839c6a7beaf
+size 54581448

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.83-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.83-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3f59f8ff75b92073f57a4a6ceccdc6d7905b1abdbd72e2a820cafca78a09491
+size 1948


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Notably the workstation kernel was built with <https://github.com/freedomofpress/kernel-builder/pull/60> to add exfat support.

Refs <https://github.com/freedomofpress/securedrop-workstation/issues/1267>.

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs).
  - https://github.com/freedomofpress/build-logs/commit/bc810df48bfb8718b83ea76a5778b7fc8d476c0a
  -  https://github.com/freedomofpress/build-logs/commit/11c42ab204be2eaa6625acecd2373f76f3ac9547
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] ~~Build locally and compare sha256sum hashes (if reproducible)~~
- [x] For kernel packages only: source tarball uploaded internally
