### PR TITLE
Fix double signing on pushes

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -44,6 +44,10 @@ jobs:
             - name: Sign packages
               run: |
                 ./.github/workflows/build.py
+                # If the only thing that build.py changed is repo/db/checksums.db, reset it
+                if [[ "$(git diff --name-only)" == "repo/db/checksums.db" ]]; then
+                  git checkout repo/db/checksums.db
+                fi
                 git add .
             - name: Update metadata
               run: |


### PR DESCRIPTION


## Status

Ready for review 
## Description of changes

GHA is currently pushing two commits after new debs are committed because the output is not fully idempotent. Running build.py always modifies the repo/db/checksums.db file, which we already knew was a problem from securedrop-apt-prod's CI.

So the fix is to run build.py, if the only thing it touched is checksums.db, reset it and move on. The update metadata export step will get skipped because nothing has changed, and no new commit will be created.

Refs #267.

## Checklist
- [ ] visual review
- [ ] observe https://github.com/freedomofpress/securedrop-apt-test/commits/debug/ - when this change was pushed to a debug branch ("Try this"), only one follow-up commit happened, not two.
- [ ] in https://github.com/freedomofpress/securedrop-apt-test/actions/runs/14117977168/job/39552538614, under "Sign packages", the very last line is "Updated 1 path from the index", which is the output generated by the new `git checkout ...` line.