### PR TITLE
Fix update-tor workflow

### DIFF
--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -31,13 +31,13 @@ jobs:
                 # Import the Tor repo signing key
                 gpg --import repo/conf/updates-keys/*.gpg
                 # Run reprepro update, skip export since we just want the debs
-                REPREPRO_BASE_DIR=repo reprepro --export=never update
+                reprepro --basedir repo --outdir repo/public --export=never update
 
-                # Move the new packages over, intentionally leaving the old ones around
-                mv repo/pool/main/t/tor/*focal*.deb core/focal/
-                mv repo/pool/main/t/tor/*noble*.deb core/noble/
+                # Copy the new packages over, intentionally leaving the old ones around
+                cp repo/public/pool/main/t/tor/*focal*.deb core/focal/
+                cp repo/public/pool/main/t/tor/*noble*.deb core/noble/
                 git add core/focal/*.deb
                 git add core/noble/*.deb
-                # If there are changes, diff-index will fail, so we commit and push
-                git diff-index --quiet HEAD || (git commit -m "Automatically updating Tor packages" \
+                # If there are staged changes, git diff will fail, so we commit and push
+                git diff --staged --exit-code || (git commit -m "Automatically updating Tor packages" \
                     && git push origin main && ./scripts/new-tor-issue)


### PR DESCRIPTION

## Status

Ready for review 

## Description of changes

Because the database is now committed to Git, the `reprepro update` command is smarter and won't download the upstream debs if they're already present in the repository.

This is generally good, but we want copies in our core/{focal,noble} folders. Have reprepro update the copy in repo/public/pool, copy the latest version of those debs over to our core/ folders. Git will commit just the new core/ debs, and the next commit will trigger re-signing.

Refs #267.


## Checklist
- [x] visual review
- [x] https://github.com/freedomofpress/securedrop-apt-test/actions/runs/14137632329/job/39612995573 passed and log looks good (it's been failing every night there hasn't been new packages)