### PR TITLE
Add SecureDrop  2.12.2-rc1 focal and noble packages.

### DIFF
--- a/core/focal/securedrop-app-code-dbgsym_2.12.2~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code-dbgsym_2.12.2~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74d403df19d3053a635cdc03027eb167f20884b99fcf88e86d4bb612ca822101
+size 1038204

--- a/core/focal/securedrop-app-code_2.12.2~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.12.2~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdf43805aadd7a428bc3cfedc472b45e0f5d3e51e48d17a896d8d7f52dd5adbc
+size 14898016

--- a/core/focal/securedrop-config-dbgsym_2.12.2~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-config-dbgsym_2.12.2~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce2b6952964f1b0a84c66ab5c4d3023228d5f1baf9ac05793f44d365f88c5bdd
+size 69564

--- a/core/focal/securedrop-config_2.12.2~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-config_2.12.2~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe66af53a76f0f35ebeb7ec351f5fae0da4b46e9778c311de30ef29c91282f71
+size 438232

--- a/core/focal/securedrop-keyring_0.2.2+2.12.2~rc1+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.2+2.12.2~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c71e0d53de1d8c65a07884298a420e3c7da71baec6f7c512cf1f8e94078c9e9
+size 7596

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.12.2~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.12.2~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e8792ad3c9f2da0b4120ec02caf3d1c5ed5e3ae983bab4b416f432d03700a98
+size 5064

--- a/core/focal/securedrop-ossec-server_3.6.0+2.12.2~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.12.2~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c492d5d3f6571d0d5a72a3237d6faf420041f2b62404876c0ea71dd8084cee2
+size 8884

--- a/core/noble/securedrop-app-code-dbgsym_2.12.2~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code-dbgsym_2.12.2~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d7999afd8ada43ffc6e8d100895000d2642946dd45f1aa3a56347f16f083a1a
+size 1000158

--- a/core/noble/securedrop-app-code_2.12.2~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code_2.12.2~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:893ed6e93e84915d8140a091f64d465dd767bcd49da735d7cd4ac93f612d7245
+size 13523662

--- a/core/noble/securedrop-config-dbgsym_2.12.2~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-config-dbgsym_2.12.2~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7b902fcae93fb0469def061ccd6740d975842be47fe19e5840edc1049a681ff
+size 74764

--- a/core/noble/securedrop-config_2.12.2~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-config_2.12.2~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1237f7d96d411f48d15101809d2930d3f03f1293f84a16de5f2fea637072c5de
+size 477774

--- a/core/noble/securedrop-keyring_0.2.2+2.12.2~rc1+noble_all.deb
+++ b/core/noble/securedrop-keyring_0.2.2+2.12.2~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b0f35568e4d11f87c9acb90750b3f404410af7b596db0fd4d6f55bc907a2a4e
+size 7384

--- a/core/noble/securedrop-ossec-agent_3.6.0+2.12.2~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-agent_3.6.0+2.12.2~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35ea7ff5ebed2ffafb1542ed24096b832fbc6b42b0ea2548f705fb6560676244
+size 5042

--- a/core/noble/securedrop-ossec-server_3.6.0+2.12.2~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-server_3.6.0+2.12.2~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82f50ef6ad2a3c211a6a0dcba0b97487c136b772c23b2f118e4683722a6126f8
+size 8996


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of changes

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/e9619c5e03a01ae75d22f7ae2a7e0f52b7472413
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
