### PR TITLE
Add SecureDrop 2.12.2-rc2 packages

### DIFF
--- a/core/focal/securedrop-app-code-dbgsym_2.12.2~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code-dbgsym_2.12.2~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3583d42b8c392364c2e4eb88f2ae1d726c2921543c9f1636987065ea0b638d94
+size 1038364

--- a/core/focal/securedrop-app-code_2.12.2~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.12.2~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c5ea61c632eda26557f4b3366cea36d271a3483f676f9f13af184eb25c7e13b
+size 14893316

--- a/core/focal/securedrop-config-dbgsym_2.12.2~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-config-dbgsym_2.12.2~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb3be1a07325a4d771ac172cb6146be33f8f43ed0a4ee9c43d55229531b57287
+size 69532

--- a/core/focal/securedrop-config_2.12.2~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-config_2.12.2~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aeecc754bc09fc538a2ca746396fb88e81aada8832d4a66e4b398e07b4f0ad86
+size 438360

--- a/core/focal/securedrop-keyring_0.2.2+2.12.2~rc2+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.2+2.12.2~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61b869c6e3fc492ef909906a8b7eb3e24c72a9707e20315c2f73da93cb5c38ae
+size 7604

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.12.2~rc2+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.12.2~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e645362ff4bcbad49837d91bdbd2f2e85129c25b538610a00371995514211ec5
+size 5068

--- a/core/focal/securedrop-ossec-server_3.6.0+2.12.2~rc2+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.12.2~rc2+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9766ae9ba83b1b932206e370627b0b6b7146716bdbd7538a469a2b7da619fdef
+size 8896

--- a/core/noble/securedrop-app-code-dbgsym_2.12.2~rc2+noble_amd64.deb
+++ b/core/noble/securedrop-app-code-dbgsym_2.12.2~rc2+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3438444f156595efb5dc3706e7279135e20b2c507c5f91975076ee0ea27e286
+size 999344

--- a/core/noble/securedrop-app-code_2.12.2~rc2+noble_amd64.deb
+++ b/core/noble/securedrop-app-code_2.12.2~rc2+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfb8ece18c732020800205c01e28945f11f47d4f6ccbdbda97efc53ded53e3a2
+size 13527890

--- a/core/noble/securedrop-config-dbgsym_2.12.2~rc2+noble_amd64.deb
+++ b/core/noble/securedrop-config-dbgsym_2.12.2~rc2+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0241a3d98f49ad4abc75294a262c2dcd73f378814a92d22c25251f22ce352bfc
+size 74216

--- a/core/noble/securedrop-config_2.12.2~rc2+noble_amd64.deb
+++ b/core/noble/securedrop-config_2.12.2~rc2+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e267a57fd9ff2a14d38459baccbaa645152b509744914d84ae8a8d727b725ac
+size 477902

--- a/core/noble/securedrop-keyring_0.2.2+2.12.2~rc2+noble_all.deb
+++ b/core/noble/securedrop-keyring_0.2.2+2.12.2~rc2+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:269820360b3b71cefca708607b658ea873fc1c32c603dd218e9e16b47f17e51e
+size 7394

--- a/core/noble/securedrop-ossec-agent_3.6.0+2.12.2~rc2+noble_all.deb
+++ b/core/noble/securedrop-ossec-agent_3.6.0+2.12.2~rc2+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed1498726df557b4b195a1434be31cdf82a83b4a28da4582dcb66aa3cead3a9c
+size 5054

--- a/core/noble/securedrop-ossec-server_3.6.0+2.12.2~rc2+noble_all.deb
+++ b/core/noble/securedrop-ossec-server_3.6.0+2.12.2~rc2+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:914e4fa91567412d1db9099196e80ff52b18f6910b69ccb3728705ee50ec3ab3
+size 9006


### PR DESCRIPTION
## Status

Ready for review 
## Description of changes

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/06698b5237aa77d022c315494a135e252e86b3c8
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
