### PR TITLE
April kernel update: Linux 5.15.180 and 6.6.88

### DIFF
--- a/core/focal/linux-headers-5.15.180-1-grsec-securedrop_5.15.180-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.180-1-grsec-securedrop_5.15.180-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bb32c205c080eebef3b7de4ec819547d500a75c348f52d577a97a7596779e26
+size 8858956

--- a/core/focal/linux-image-5.15.180-1-grsec-securedrop_5.15.180-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.180-1-grsec-securedrop_5.15.180-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75350e2cb4166544075e5b43670fd3d9d05bfc97d1040703c6a5618675c5d2dc
+size 47730752

--- a/core/focal/securedrop-grsec_5.15.180-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.180-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb4c72d97f08f36be98da50eab68cf3bdb026f8ff5d8e83ffdb974b1eb634bc4
+size 3328

--- a/core/noble/linux-headers-6.6.88-1-grsec-securedrop_6.6.88-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-headers-6.6.88-1-grsec-securedrop_6.6.88-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:742f3a7146e81d18d5156a08b39cd9ffc073df70ad36737972d09bcc8ba0b951
+size 9516332

--- a/core/noble/linux-image-6.6.88-1-grsec-securedrop_6.6.88-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-image-6.6.88-1-grsec-securedrop_6.6.88-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3804670a8bdd0d4c6adcac8a74b8743d474069360e93095601bd30527cdc0ff
+size 53754980

--- a/core/noble/securedrop-grsec_6.6.88-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/securedrop-grsec_6.6.88-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:003841c4d5b7effa842ab7f8128af483561a8bbf9ad309d840eabb4d06045cd6
+size 3328

--- a/workstation/bookworm/linux-headers-6.6.88-1-grsec-workstation_6.6.88-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.88-1-grsec-workstation_6.6.88-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:077aa2d2b09e4ba663065317185b9ecd300dfa595938eda1964c7778651be420
+size 9425356

--- a/workstation/bookworm/linux-image-6.6.88-1-grsec-workstation_6.6.88-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.88-1-grsec-workstation_6.6.88-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a52d86e9b781f484b845cbf74b7ed9844cbc0e35244c5589b929c930a84d65f9
+size 44191104

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.88-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.88-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0f06f5df2d4811c9cc6d37d6e008dc29202d109c361ca1ffb2b5a3521096f21
+size 1948


### PR DESCRIPTION
## Status

Ready for review


## Description of changes

Towards freedomofpress/securedrop#7511.


## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs):
    - v5.15.180: freedomofpress/build-logs@426208e71a21f96291b51f3f45bb874c3d094a6b
    - v6.6.88: freedomofpress/build-logs@67da58c6c9ad552919abd650ec81af821a6a8ef2
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
- [x] For kernel packages only: source tarball uploaded internally