### PR TITLE
May kernel update: Linux 5.15.81 and 6.6.89

### DIFF
--- a/core/focal/linux-headers-5.15.181-1-grsec-securedrop_5.15.181-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.181-1-grsec-securedrop_5.15.181-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7acb5c7709bbf2f1f5b4e84d5d33656166a9be5ccfb43b565dd87820b9490cb
+size 25633736

--- a/core/focal/linux-image-5.15.181-1-grsec-securedrop_5.15.181-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.181-1-grsec-securedrop_5.15.181-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:892a1440cf593c0e43584502904f963dc1e1d7e474a4a57aa63b18180c100e70
+size 61429780

--- a/core/focal/securedrop-grsec_5.15.181-1-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.181-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef66c96e11fb529237eb1671f4938a2be8fef341d152a828b8ac91cd48e969a6
+size 3328

--- a/core/noble/linux-headers-6.6.89-1-grsec-securedrop_6.6.89-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-headers-6.6.89-1-grsec-securedrop_6.6.89-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ef0fb4a16d68952b050713e05a5689a43b28e7d4b729a8f8819cff10c23423
+size 25130696

--- a/core/noble/linux-image-6.6.89-1-grsec-securedrop_6.6.89-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-image-6.6.89-1-grsec-securedrop_6.6.89-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64ac2372b96480226d069c615af4da1c6f9ac318e654c6ae4992a5d8a2b93196
+size 70776280

--- a/core/noble/securedrop-grsec_6.6.89-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/securedrop-grsec_6.6.89-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5209a52d56ca1a6bd1f1a03756a70ec04539c228c8315d75f69bb64294af544
+size 3328

--- a/workstation/bookworm/linux-headers-6.6.89-1-grsec-workstation_6.6.89-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.89-1-grsec-workstation_6.6.89-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f35f559067b7ba846795fc015c48c62e15a7a6b375053600a2eaac468f3773f8
+size 25110880

--- a/workstation/bookworm/linux-image-6.6.89-1-grsec-workstation_6.6.89-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.89-1-grsec-workstation_6.6.89-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9bcf209f41b9356e071f5d86daa6ab61cef9025aff436e505dabc68e19dbf2a
+size 54636220

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.89-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.89-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0885718df27cb8691f8b4afad1abafa2412bab515b7d75c7365ebb923557830
+size 1948


### PR DESCRIPTION
## Status

Ready for review


## Description of changes

Towards freedomofpress/securedrop#7511.


## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs):
    - v5.15.18: freedomofpress/build-logs@5eae5a374c1b5aa06d0f19f131e2d661ccba4b8b
    - v6.6.89: freedomofpress/build-logs@0d66bd86605305a55346e0d2e8c050613414185c
- [x] **grsecurity patches are evident in the build logs**
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
- [x] For kernel packages only: source tarball uploaded internally