### PR TITLE
Add SecureDrop Client 0.15.0-rc1 debs

### DIFF
--- a/workstation/bookworm/securedrop-client-dbgsym_0.15.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_0.15.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7e76d9995a9ae621750c91d746cd79fcbf7aba8c4df48a4b2311c8ff0aabe7c
+size 49716

--- a/workstation/bookworm/securedrop-client_0.15.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_0.15.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:901d7da92a67042c90d49a637fc2e44aabda06d1d419c835f517dd2178e73244
+size 4931832

--- a/workstation/bookworm/securedrop-export_0.15.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_0.15.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94f7fdecd555b892733f18cd3e9d11f814314ebfbc290226ce8ff75f59c45267
+size 1642980

--- a/workstation/bookworm/securedrop-keyring_0.15.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_0.15.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:532b76d530b8db79f9c457f0b3f1ca01353f05258686e0c68f65ac6892e99dc3
+size 10028

--- a/workstation/bookworm/securedrop-log_0.15.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_0.15.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48b5dff381844be7362a38b639d357171102dcd93825c16b990aab65fdb43d30
+size 1611352

--- a/workstation/bookworm/securedrop-proxy-dbgsym_0.15.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_0.15.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6edfd56dec640eca0e66ade39333f704c94e2d9e27dde93397e7f8ed2feb0747
+size 11681464

--- a/workstation/bookworm/securedrop-proxy_0.15.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_0.15.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de66cb6278f8af879d3718152a11bde1a73a85048b4084ea2a1b160a9c922277
+size 1031580

--- a/workstation/bookworm/securedrop-qubesdb-tools_0.15.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-qubesdb-tools_0.15.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45918acac77e702bee15f165fd328588cc2df1b8cbf2929a693d38446b66e061
+size 4180

--- a/workstation/bookworm/securedrop-whonix-config_0.15.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-whonix-config_0.15.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b5043af987895d6fccbcc8653266a2b56f5537278633f96258311ad098b2faf
+size 4752

--- a/workstation/bookworm/securedrop-workstation-config_0.15.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_0.15.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e382bc3e2a9cb938cdd150ab4630bd531204a14c57a7b0fff0696e118c1bcb48
+size 9512

--- a/workstation/bookworm/securedrop-workstation-viewer_0.15.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_0.15.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6979fefce6324b6972f86ac867dfd91e5ecc4b399dd32b3e8bff183f1d6be12
+size 3728


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs). 
  - see https://github.com/freedomofpress/build-logs/pull/13
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
