### PR TITLE
Add SecureDrop 2.12.9-rc1 packages.

### DIFF
--- a/core/focal/securedrop-app-code-dbgsym_2.12.9~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code-dbgsym_2.12.9~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4aa187827dc4207820579e0ca85ec66db9e4adcae4e75d425d7b82836dc8b52c
+size 1038360

--- a/core/focal/securedrop-app-code_2.12.9~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.12.9~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c412e202147d3bb1dd788c7f161bd1e7baf76f404f02bab554a40adddd497d58
+size 14903804

--- a/core/focal/securedrop-config-dbgsym_2.12.9~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-config-dbgsym_2.12.9~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:187414db9288a329c5aad52a0bc985ab42da6d6d61a1e990674b1105673f7d53
+size 73516

--- a/core/focal/securedrop-config_2.12.9~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-config_2.12.9~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8650c64a74d873d4c07a135a2a3ef6c452875bc21dd56b8da31e4e1e4649985
+size 436520

--- a/core/focal/securedrop-keyring_0.2.2+2.12.9~rc1+focal_all.deb
+++ b/core/focal/securedrop-keyring_0.2.2+2.12.9~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0cbc12dd3430ff584fd405bfc1d54526ba7f8333fa6e7f16a03c79d181e1183
+size 7692

--- a/core/focal/securedrop-ossec-agent_3.6.0+2.12.9~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-agent_3.6.0+2.12.9~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:956231ea28a0fe15b976f499b9f7a4f3e97ee85267b2e9c94fb3f8a38326a2b2
+size 5160

--- a/core/focal/securedrop-ossec-server_3.6.0+2.12.9~rc1+focal_all.deb
+++ b/core/focal/securedrop-ossec-server_3.6.0+2.12.9~rc1+focal_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06cf0404ac4c008545641692bb1c1e9d7436206f771a41098cc2d1d80fc61570
+size 8980

--- a/core/noble/securedrop-app-code-dbgsym_2.12.9~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code-dbgsym_2.12.9~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8475df6b0d01b0952f779d787aa54d3b9b739e88e24aaa1c1dc1f5e4101d5ce0
+size 999574

--- a/core/noble/securedrop-app-code_2.12.9~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code_2.12.9~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:147ef694c6b5bfb32c98092cc7b0d005b315b366653b0a7ccdfedd5620bf8f88
+size 13805668

--- a/core/noble/securedrop-config-dbgsym_2.12.9~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-config-dbgsym_2.12.9~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a4b7515f32178ca7897f75f920041feeefd00166785c979ec632f06ef1d247d
+size 75756

--- a/core/noble/securedrop-config_2.12.9~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-config_2.12.9~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b53ffce8bc89c4f8aa142ad090237f7e2bb71f75dad2b5a6e026c54364b4e4db
+size 475352

--- a/core/noble/securedrop-keyring_0.2.2+2.12.9~rc1+noble_all.deb
+++ b/core/noble/securedrop-keyring_0.2.2+2.12.9~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a7aa89b748127b2f05c573621aa02d1ae1701e9ee3d95a01eb6705031787009
+size 7486

--- a/core/noble/securedrop-ossec-agent_3.6.0+2.12.9~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-agent_3.6.0+2.12.9~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a43dbc89a721c85fb5c44d9f14aca6dd27607931eb5af18ea2124288abd82d1d
+size 5162

--- a/core/noble/securedrop-ossec-server_3.6.0+2.12.9~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-server_3.6.0+2.12.9~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a07d43e9e09d9239ea7666837165d800bcd373efc76e75e37d9b2e9ae5c1287f
+size 9118


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Build metadata has been committed to https://github.com/freedomofpress/build-logs/commit/21ef78196f964ee91b90776ba4f6dbf940764532
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)
- [ ] ~For kernel packages only: source tarball uploaded internally~
