### PR TITLE
Linux 6.6.102

### DIFF
--- a/core/noble/linux-headers-6.6.102-1-grsec-securedrop_6.6.102-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-headers-6.6.102-1-grsec-securedrop_6.6.102-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d606fb1e4e6916676e590fe30be6cb33cf3d0a3fff41e29d417f4d99a9bc8b91
+size 25160840

--- a/core/noble/linux-image-6.6.102-1-grsec-securedrop_6.6.102-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-image-6.6.102-1-grsec-securedrop_6.6.102-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a83a59813d45583020c107ef3a869778e4895fc5574914eb99ab8e932dbb7b5
+size 71441068

--- a/core/noble/securedrop-grsec_6.6.102-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/securedrop-grsec_6.6.102-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:532137706e14ee09ea336e80b4ca7e4204d3857234d5c466e3c19457dd1a8f80
+size 3328

--- a/workstation/bookworm/linux-headers-6.6.102-1-grsec-workstation_6.6.102-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.102-1-grsec-workstation_6.6.102-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a82c46c5d0988189f11e0008559e0f4092a444909f9fbfec01a00f29239ca2cc
+size 25116428

--- a/workstation/bookworm/linux-image-6.6.102-1-grsec-workstation_6.6.102-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.102-1-grsec-workstation_6.6.102-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7620a9dfab23ca6b2f9d31e4d8e8768f9e6129a21570d2c4a059e69e444d0fd9
+size 55180576

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.102-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.102-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ba47f9add2d65165ad70366b28ae8d30550f107270e90df5a4e8e507bf9621a
+size 1948


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/6dfa6a93ecabcb3777ef8620c3656de8d249885a
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
- [x] For kernel packages only: source tarball uploaded internally
