### PR TITLE
Add securedrop-arti 1.4.6

### DIFF
--- a/workstation/bookworm/securedrop-arti-dbgsym_1.4.6+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-arti-dbgsym_1.4.6+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50a86850dcb21aa99452ad97be00b50ca17817ce655d08e5ba1aeb80fb57c08d
+size 27493988

--- a/workstation/bookworm/securedrop-arti_1.4.6+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-arti_1.4.6+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:287963076d9d705c13fda80a3b05b6a6ae7f734a95accca8abb838ed0969fef9
+size 3715968


### PR DESCRIPTION
Fixes <https://github.com/freedomofpress/securedrop-workstation/issues/1381>.

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/fa71bc8468037573aa0be14f3e4e08bc9cfc093a
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes 