### PR TITLE
Add SecureDrop Client 0.17.0-rc1

### DIFF
--- a/workstation/bookworm/securedrop-client-dbgsym_0.17.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_0.17.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2b4666e1f4bcc2d510637304be89fd22650c7bbf51c5107710899dd1be37a94
+size 49720

--- a/workstation/bookworm/securedrop-client_0.17.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_0.17.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f023734d7cba2bf92f66dd0492be41b46683e6973dcdf491b67aa3034e149e33
+size 3895592

--- a/workstation/bookworm/securedrop-export_0.17.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_0.17.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dbc7e10d5f89be60c4c7cc2e330fb57ff99d89f4200f76dd435c2f511dafd0e
+size 1643204

--- a/workstation/bookworm/securedrop-keyring_0.17.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_0.17.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65084653f2200800c5a7b2896df2611465db5d04581584cc3f07bd7ac26d34c3
+size 10064

--- a/workstation/bookworm/securedrop-log_0.17.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_0.17.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dd73dc48d4b4a6e46b474fe5826952abd812314f0eac3e81e5fbe48563baab0
+size 1611988

--- a/workstation/bookworm/securedrop-proxy-dbgsym_0.17.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_0.17.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e0302bfa5a8bce6b19de88d978837fc53b3b6ef079901671d45940a22048cd4
+size 11356376

--- a/workstation/bookworm/securedrop-proxy_0.17.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_0.17.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abca9c7435f03069457f820bc35270e8f561e108d478ef6a5350edcd77cd102c
+size 1046712

--- a/workstation/bookworm/securedrop-qubesdb-tools_0.17.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-qubesdb-tools_0.17.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdc428b331c41b49d86f46888aa1c65e999b6ae021e064d3d546bb95f006ba44
+size 4220

--- a/workstation/bookworm/securedrop-workstation-config_0.17.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_0.17.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11af7e1d6d6b8c11482cd036dd72e6f6a7f60163a1d8bfbcc558eea45dab790d
+size 9476

--- a/workstation/bookworm/securedrop-workstation-viewer_0.17.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_0.17.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b21b5205dcd06e932ed93ca456ac31f0cb67d9d18a3fc3d162d6409d6f9c0ca1
+size 3764


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Refs https://github.com/freedomofpress/securedrop-client/issues/2660.

## Checklist
- [ ] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/077574339b38e3e4391962fee60b47140330e3e1
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)

