### PR TITLE
Add SecureDrop Client 0.17.0-rc2

### DIFF
--- a/workstation/bookworm/securedrop-client-dbgsym_0.17.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_0.17.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bb6c3ce0dc8230e0a608223440d9b435f50c261c99665299c4fce972368b49c
+size 49712

--- a/workstation/bookworm/securedrop-client_0.17.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_0.17.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3e415e281d0c97b71d4e82a6c0eda5090f4ac5fa495607941c865dec223de42
+size 3895224

--- a/workstation/bookworm/securedrop-export_0.17.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_0.17.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c24b486ff74b51c6a07abd63f79e7e62737cff3b635d79df841883eaf252fa4a
+size 1643408

--- a/workstation/bookworm/securedrop-keyring_0.17.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_0.17.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3bd723f5962850a92ba2128e54a593ecd97bcb83ab6a81d20b19e05a6a933ed
+size 10092

--- a/workstation/bookworm/securedrop-log_0.17.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_0.17.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2a04a77a29aacf7d8535892b7dbf0b99d0611d5c7046a75810f3603d85184e3
+size 1611532

--- a/workstation/bookworm/securedrop-proxy-dbgsym_0.17.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_0.17.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02c4503a1bf7a4ebbfca2b0848c9929212f683a9df365b07aad6a71c5dfbedd0
+size 11356376

--- a/workstation/bookworm/securedrop-proxy_0.17.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_0.17.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b1e7e149a8e892f29022653e10f399acfd05d5bb04f9f040cb24fa02f1e9b69
+size 1045976

--- a/workstation/bookworm/securedrop-qubesdb-tools_0.17.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-qubesdb-tools_0.17.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1db6256826e1a9a8e78d1e53ec27e863ca1a287baba0c8a8b2d1412e417623d0
+size 4240

--- a/workstation/bookworm/securedrop-workstation-config_0.17.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_0.17.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcb401e1933b230c50fd904977a8734e722f3510836fb69b75c1ebf9513027e4
+size 9488

--- a/workstation/bookworm/securedrop-workstation-viewer_0.17.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_0.17.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88a4b234512487375c8a9b4b414e44f5e7859f930418f6524afc53e2b3c9e458
+size 3784


### PR DESCRIPTION
## Status

Ready for review.

## Description of changes

Add SecureDrop Client 0.17.0-rc1 packages. Build logs uploaded to https://github.com/freedomofpress/build-logs/commit/1459d2c5d9d154cb1747bc41065928cdac0af73f.


## Checklist
- [ ] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs).
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
