### PR TITLE
Fix tor-bookworm

### DIFF
--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -14,3 +14,4 @@ Architectures: amd64
 ValidFor: 6m
 Description: SecureDrop Workstation packages (bookworm)
 SignWith: 83127F68BABB04F3FE9A69AA545E94503FAB65AB
+Update: tor-bookworm

--- a/workstation/bookworm/tor-dbgsym_0.4.8.17-1~d12.bookworm+1_amd64.deb
+++ b/workstation/bookworm/tor-dbgsym_0.4.8.17-1~d12.bookworm+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:524df1165e15a089af3289db1a48f30c223ce4a8ef8e62d227593cf874ac1d7a
+size 5758416

--- a/workstation/bookworm/tor-geoipdb_0.4.8.17-1~d12.bookworm+1_all.deb
+++ b/workstation/bookworm/tor-geoipdb_0.4.8.17-1~d12.bookworm+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dbb9c2d4fa7dd4e0132bc6504d8289603e166313350ab73329cfe772c1b0b25
+size 2449256

--- a/workstation/bookworm/tor_0.4.8.17-1~d12.bookworm+1_amd64.deb
+++ b/workstation/bookworm/tor_0.4.8.17-1~d12.bookworm+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c13085eb42ba88311764cb15c962f6e0e4fccdc8062305ecbdd09e60e2c0e642
+size 2055716


### PR DESCRIPTION
## Status

Ready for review
## Description of changes

* Fix the missing `Update` stanza so the automation actually works
* Add the debs manually for now so we don't have to wait until 7am UTC.

## Checklist
- [ ] ~~Build locally and compare sha256sum hashes (if reproducible)~~ Verify packages are identical to https://deb.torproject.org/torproject.org/pool/main/t/tor/
